### PR TITLE
rename fields

### DIFF
--- a/contracts/IPaymaster.sol
+++ b/contracts/IPaymaster.sol
@@ -17,7 +17,7 @@ interface IPaymaster {
     // @param maxcost the maximum cost of this transaction (based on maximum gas and gas price from userOp)
     // @returns context value to send to a postOp
     //  zero length to signify postOp is not required.
-    function payForOp(UserOperation calldata userOp, uint maxcost) external view returns (bytes memory context);
+    function verifyPaymasterUserOp(UserOperation calldata userOp, uint maxcost) external view returns (bytes memory context);
 
     // post-operation handler.
     // @param mode
@@ -25,7 +25,7 @@ interface IPaymaster {
     //      opReverted  - user op reverted. still has to pay for gas.
     //      postOpReverted - user op succeeded, but caused postOp (in mode=opSucceeded) to revert.
     //                       Now this is the 2nd call, after user's op was deliberately reverted.
-    // @param context - the context value returned by payForOp
+    // @param context - the context value returned by verifyPaymasterUserOp
     // @param actualGasCost - actual gas used so far (without this postOp call).
     function postOp(PostOpMode mode, bytes calldata context, uint actualGasCost) external;
 }

--- a/contracts/IWallet.sol
+++ b/contracts/IWallet.sol
@@ -9,8 +9,6 @@ interface IWallet {
     // @param requiredPrefund how much this wallet should pre-fund the transaction.
     // @note that after execution, the excess is sent back to the wallet.
     // @note if requiredPrefund is zero, the wallet MUST NOT send anything (the paymaster pays)
-    function payForSelfOp(UserOperation calldata userOp, uint requiredPrefund) external;
+    function verifyUserOp(UserOperation calldata userOp, uint requiredPrefund) external;
 
-    //called by singleton, only after payForSelfOp succeeded.
-    function execFromSingleton(bytes calldata func) external;
 }

--- a/contracts/UserOperation.sol
+++ b/contracts/UserOperation.sol
@@ -5,12 +5,13 @@ import "hardhat/console.sol";
 
     struct UserOperation {
 
-        address target;
+        address sender;
         uint256 nonce;
         bytes initCode;
         bytes callData;
         uint callGas;
         uint verificationGas;
+        uint preVerificationGas;
         uint maxFeePerGas;
         uint maxPriorityFeePerGas;
         address paymaster;
@@ -45,12 +46,13 @@ library UserOperationLib {
     function pack(UserOperation memory userOp) internal pure returns (bytes memory) {
         //TODO: eip712-style ?
         return abi.encode(
-            userOp.target,
+            userOp.sender,
             userOp.nonce,
             keccak256(userOp.initCode),
             keccak256(userOp.callData),
             userOp.callGas,
             userOp.verificationGas,
+            userOp.preVerificationGas,
             userOp.maxFeePerGas,
             userOp.maxPriorityFeePerGas,
             userOp.paymaster,

--- a/contracts/samples/SimpleWallet.sol
+++ b/contracts/samples/SimpleWallet.sol
@@ -59,7 +59,7 @@ contract SimpleWallet is IWallet {
     }
 
     //called by entryPoint, only after verifyUserOp succeeded.
-    function execFromEntryPoint(bytes calldata func) external override {
+    function execFromEntryPoint(bytes calldata func) external {
         require(msg.sender == entryPoint, "execFromEntryPoint: only from entryPoint");
         _call(address(this), func);
     }

--- a/contracts/samples/SimpleWallet.sol
+++ b/contracts/samples/SimpleWallet.sol
@@ -7,19 +7,19 @@ import "hardhat/console.sol";
 //minimal wallet
 // this is sample minimal wallet.
 // has execute, eth handling methods
-// has a single signer that can send requests through the singleton.
+// has a single signer that can send requests through the entryPoint.
 contract SimpleWallet is IWallet {
     using UserOperationLib for UserOperation;
     uint public nonce;
     address public owner;
-    address public singleton;
+    address public entryPoint;
 
-    event SingletonChanged(address oldSingleton, address newSingleton);
+    event EntryPointChanged(address oldEntryPoint, address newEntryPoint);
 
     receive() external payable {}
 
-    constructor(address _singleton, address _owner) {
-        singleton = _singleton;
+    constructor(address _entryPoint, address _owner) {
+        entryPoint = _entryPoint;
         owner = _owner;
     }
 
@@ -29,7 +29,7 @@ contract SimpleWallet is IWallet {
     }
 
     function _onlyOwner() internal view {
-        //directly from EOA owner, or through the singleton (which gets redirected through execFromSingleton)
+        //directly from EOA owner, or through the entryPoint (which gets redirected through execFromEntryPoint)
         require(msg.sender == owner || msg.sender == address(this), "only owner");
     }
 
@@ -41,31 +41,31 @@ contract SimpleWallet is IWallet {
         _call(dest, func);
     }
 
-    function updateSingleton(address _singleton) external onlyOwner {
-        emit SingletonChanged(singleton, _singleton);
-        singleton = _singleton;
+    function updateEntryPoint(address _entryPoint) external onlyOwner {
+        emit EntryPointChanged(entryPoint, _entryPoint);
+        entryPoint = _entryPoint;
     }
 
-    function payForSelfOp(UserOperation calldata userOp, uint requiredPrefund) external override {
-        require(msg.sender == singleton, "wallet: not from Singleton");
+    function verifyUserOp(UserOperation calldata userOp, uint requiredPrefund) external override {
+        require(msg.sender == entryPoint, "wallet: not from EntryPoint");
         _validateSignature(userOp);
         _validateAndIncrementNonce(userOp);
 
         if (requiredPrefund != 0) {
             (bool success) = payable(msg.sender).send(requiredPrefund);
             (success);
-            //ignore failure (its Singleton's job to verify, not wallet.)
+            //ignore failure (its EntryPoint's job to verify, not wallet.)
         }
     }
 
-    //called by singleton, only after payForSelfOp succeeded.
-    function execFromSingleton(bytes calldata func) external override {
-        require(msg.sender == singleton, "execFromSingleton: only from singleton");
+    //called by entryPoint, only after verifyUserOp succeeded.
+    function execFromEntryPoint(bytes calldata func) external override {
+        require(msg.sender == entryPoint, "execFromEntryPoint: only from entryPoint");
         _call(address(this), func);
     }
 
-    function _call(address target, bytes memory data) internal {
-        (bool success, bytes memory result) = target.call(data);
+    function _call(address sender, bytes memory data) internal {
+        (bool success, bytes memory result) = sender.call(data);
         if (!success) {
             assembly {
                 revert(result, add(result, 32))

--- a/contracts/samples/SimpleWalletForTokens.sol
+++ b/contracts/samples/SimpleWalletForTokens.sol
@@ -8,7 +8,7 @@ import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 // the simplest strategy is assign the allowance in the constructor or init function
 contract SimpleWalletForTokens is SimpleWallet {
 
-    constructor(address _singleton, address _owner, IERC20 token, address paymaster) SimpleWallet(_singleton, _owner) {
+    constructor(address _entryPoint, address _owner, IERC20 token, address paymaster) SimpleWallet(_entryPoint, _owner) {
         token.approve(paymaster, type(uint).max);
     }
 }

--- a/contracts/samples/TestToken.sol
+++ b/contracts/samples/TestToken.sol
@@ -8,7 +8,7 @@ contract TestToken is ERC20 {
         ERC20("TST", "TestToken") {
     }
 
-    function mint(address target, uint amount) external {
-        _mint(target, amount);
+    function mint(address sender, uint amount) external {
+        _mint(sender, amount);
     }
 }

--- a/contracts/samples/VerifyingPaymaster.sol
+++ b/contracts/samples/VerifyingPaymaster.sol
@@ -2,7 +2,7 @@
 pragma solidity ^0.8.7;
 
 import "../IPaymaster.sol";
-import "../Singleton.sol";
+import "../EntryPoint.sol";
 
 /**
  * A sample paymaster that uses external service to decide whether to pay for the UserOp.
@@ -17,21 +17,21 @@ contract VerifyingPaymaster is IPaymaster {
 
     using UserOperationLib for UserOperation;
 
-    Singleton public immutable singleton;
+    EntryPoint public immutable entryPoint;
     address public immutable verifyingSigner;
 
-    constructor(Singleton _singleton, address _verifyingSigner) {
-        singleton = _singleton;
+    constructor(EntryPoint _entryPoint, address _verifyingSigner) {
+        entryPoint = _entryPoint;
         verifyingSigner = _verifyingSigner;
     }
 
     function addStake() external payable {
-        singleton.addStake{value : msg.value}();
+        entryPoint.addStake{value : msg.value}();
     }
 
     // verify our external signer signed this request.
     // the "paymasterData" is supposed to be a signature over the entire request params
-    function payForOp(UserOperation calldata userOp, uint requiredPreFund) external view override returns (bytes memory context) {
+    function verifyPaymasterUserOp(UserOperation calldata userOp, uint requiredPreFund) external view override returns (bytes memory context) {
         (requiredPreFund);
 
         bytes32 hash = userOp.hash();
@@ -46,7 +46,7 @@ contract VerifyingPaymaster is IPaymaster {
     }
 
     function postOp(PostOpMode, bytes calldata, uint) external pure override {
-        //should never get called. returned "0" from payForOp
+        //should never get called. returned "0" from verifyPaymasterUserOp
         revert();
     }
 }

--- a/package.json
+++ b/package.json
@@ -4,9 +4,9 @@
   "description": "",
   "scripts": {
     "clean": "rm -rf cache artifacts typechain",
-    "compile": "FORCE_COLOR=1 hardhat compile 2>&1 | ./scripts/solcErrors; ./scripts/makeUserOps",
+    "compile": "./scripts/hh-wrapper compile && yarn run makeUserOps",
     "makeUserOps": "./scripts/makeUserOps",
-    "test": "FORCE_COLOR=1 hardhat test 2>&1 | ./scripts/solcErrors;",
+    "test": "./scripts/hh-wrapper test",
     "test-dev": "hardhat test --network dev",
     "ci": "hardhat compile && hardhat test"
   },

--- a/test/UserOperation.ts
+++ b/test/UserOperation.ts
@@ -2,12 +2,13 @@ import * as typ from "./solidityTypes";
 
 export interface UserOperation {
 
-  target: typ.address
+  sender: typ.address
   nonce: typ.uint256
   initCode: typ.bytes
   callData: typ.bytes
   callGas: typ.uint
   verificationGas: typ.uint
+  preVerificationGas: typ.uint
   maxFeePerGas: typ.uint
   maxPriorityFeePerGas: typ.uint
   paymaster: typ.address

--- a/test/singleton.test.ts
+++ b/test/singleton.test.ts
@@ -5,8 +5,8 @@ import {expect} from "chai";
 import {
   SimpleWallet,
   SimpleWallet__factory,
-  Singleton,
-  Singleton__factory,
+  EntryPoint,
+  EntryPoint__factory,
   TestCounter,
   TestCounter__factory,
   TestUtil,
@@ -27,10 +27,10 @@ import {toBuffer} from "ethereumjs-util";
 import {defaultAbiCoder, parseEther} from "ethers/lib/utils";
 import exp from "constants";
 
-describe("Singleton", function () {
+describe("EntryPoint", function () {
 
-  let singleton: Singleton
-  let singletonView: Singleton
+  let entryPoint: EntryPoint
+  let entryPointView: EntryPoint
 
   let testUtil: TestUtil
   let walletOwner: Wallet
@@ -43,11 +43,11 @@ describe("Singleton", function () {
 
     await checkForGeth()
     testUtil = await new TestUtil__factory(ethersSigner).deploy()
-    singleton = await new Singleton__factory(ethersSigner).deploy(0, unstakeDelayBlocks)
+    entryPoint = await new EntryPoint__factory(ethersSigner).deploy(0, unstakeDelayBlocks)
     //static call must come from address zero, to validate it can only be called off-chain.
-    singletonView = singleton.connect(ethers.provider.getSigner(AddressZero))
+    entryPointView = entryPoint.connect(ethers.provider.getSigner(AddressZero))
     walletOwner = createWalletOwner()
-    wallet = await new SimpleWallet__factory(ethersSigner).deploy(singleton.address, await walletOwner.getAddress())
+    wallet = await new SimpleWallet__factory(ethersSigner).deploy(entryPoint.address, await walletOwner.getAddress())
     await fund(wallet)
   })
 
@@ -59,22 +59,22 @@ describe("Singleton", function () {
 
     describe('without stake', () => {
       it('should return no stake', async () => {
-        expect(await singleton.isPaymasterStaked(addr, TWO_ETH)).to.eq(false)
+        expect(await entryPoint.isPaymasterStaked(addr, TWO_ETH)).to.eq(false)
       })
       it('should fail to unlock', async () => {
-        await expect(singleton.unlockStake()).to.revertedWith('no stake')
+        await expect(entryPoint.unlockStake()).to.revertedWith('no stake')
       })
       it('should fail to withdraw', async () => {
-        await expect(singleton.withdrawStake(AddressZero)).to.revertedWith('no unlocked stake')
+        await expect(entryPoint.withdrawStake(AddressZero)).to.revertedWith('no unlocked stake')
       })
     })
     describe('with stake of 2 eth', () => {
       before(async () => {
-        await singleton.addStake({value: TWO_ETH})
+        await entryPoint.addStake({value: TWO_ETH})
       })
       it('should report "staked" state', async () => {
-        expect(await singleton.isPaymasterStaked(addr, TWO_ETH)).to.eq(true)
-        const {stake, withdrawStake, withdrawBlock} = await singleton.getStakeInfo(addr)
+        expect(await entryPoint.isPaymasterStaked(addr, TWO_ETH)).to.eq(true)
+        const {stake, withdrawStake, withdrawBlock} = await entryPoint.getStakeInfo(addr)
         expect({stake, withdrawStake, withdrawBlock}).to.eql({
           stake: parseEther('2'),
           withdrawStake: BigNumber.from(0),
@@ -87,37 +87,37 @@ describe("Singleton", function () {
       }
 
       it('should succeed to stake again', async () => {
-        const {stake} = await singleton.getStakeInfo(addr)
+        const {stake} = await entryPoint.getStakeInfo(addr)
         expect(stake).to.eq(TWO_ETH)
-        await singleton.addStake({value: ONE_ETH})
-        const {stake: stakeAfter} = await singleton.getStakeInfo(addr)
+        await entryPoint.addStake({value: ONE_ETH})
+        const {stake: stakeAfter} = await entryPoint.getStakeInfo(addr)
         expect(stakeAfter).to.eq(parseEther('3'))
       })
       it('should fail to withdraw before unlock', async () => {
-        await expect(singleton.withdrawStake(AddressZero)).to.revertedWith('no unlocked stake')
+        await expect(entryPoint.withdrawStake(AddressZero)).to.revertedWith('no unlocked stake')
       })
       describe('with unlocked stake', () => {
         before(async () => {
-          await singleton.unlockStake()
+          await entryPoint.unlockStake()
         })
         it('should report as "not staked"', async () => {
-          expect(await singleton.isPaymasterStaked(addr, TWO_ETH)).to.eq(false)
+          expect(await entryPoint.isPaymasterStaked(addr, TWO_ETH)).to.eq(false)
         })
         it('should report unstake state', async () => {
           const withdrawBlock1 = await ethers.provider.getBlockNumber() + unstakeDelayBlocks
-          const {stake, withdrawStake, withdrawBlock} = await singleton.getStakeInfo(addr)
+          const {stake, withdrawStake, withdrawBlock} = await entryPoint.getStakeInfo(addr)
           expect({stake, withdrawStake, withdrawBlock}).to.eql({
             stake: BigNumber.from(0),
             withdrawStake: parseEther('3'),
             withdrawBlock: withdrawBlock1
           })
-          expect(await singleton.isPaymasterStaked(addr, TWO_ETH)).to.eq(false)
+          expect(await entryPoint.isPaymasterStaked(addr, TWO_ETH)).to.eq(false)
         })
         it('should fail to withdraw before unlock timeout', async () => {
-          await expect(singleton.withdrawStake(AddressZero)).to.revertedWith('Withdrawal is not due')
+          await expect(entryPoint.withdrawStake(AddressZero)).to.revertedWith('Withdrawal is not due')
         })
         it('should fail to unlock again', async () => {
-          await expect(singleton.unlockStake()).to.revertedWith('already pending')
+          await expect(entryPoint.unlockStake()).to.revertedWith('already pending')
         })
         describe('after unstake delay', () => {
           before(async () => {
@@ -131,8 +131,8 @@ describe("Singleton", function () {
               snap = await ethers.provider.send('evm_snapshot', [])
 
               await ethersSigner.sendTransaction({to: addr})
-              await singleton.addStake({value: ONE_ETH})
-              const {stake, withdrawStake, withdrawBlock} = await singleton.getStakeInfo(addr)
+              await entryPoint.addStake({value: ONE_ETH})
+              const {stake, withdrawStake, withdrawBlock} = await entryPoint.getStakeInfo(addr)
               expect({stake, withdrawStake, withdrawBlock}).to.eql({
                 stake: parseEther('4'),
                 withdrawStake: parseEther('0'),
@@ -144,17 +144,17 @@ describe("Singleton", function () {
           })
 
           it('should report unstaked state', async () => {
-            expect(await singleton.isPaymasterStaked(addr, TWO_ETH)).to.eq(false)
+            expect(await entryPoint.isPaymasterStaked(addr, TWO_ETH)).to.eq(false)
           })
           it('should fail to unlock again', async () => {
-            await expect(singleton.unlockStake()).to.revertedWith('already pending')
+            await expect(entryPoint.unlockStake()).to.revertedWith('already pending')
           })
           it('should succeed to withdraw', async () => {
-            const {withdrawStake} = await singleton.getStakeInfo(addr)
+            const {withdrawStake} = await entryPoint.getStakeInfo(addr)
             const addr1 = createWalletOwner().address
-            await singleton.withdrawStake(addr1)
+            await entryPoint.withdrawStake(addr1)
             expect(await ethers.provider.getBalance(addr1)).to.eq(withdrawStake)
-            const {stake, withdrawStake: withdrawStakeAfter, withdrawBlock} = await singleton.getStakeInfo(addr)
+            const {stake, withdrawStake: withdrawStakeAfter, withdrawBlock} = await entryPoint.getStakeInfo(addr)
 
             expect({stake, withdrawStakeAfter, withdrawBlock}).to.eql({
               stake: BigNumber.from(0),
@@ -163,7 +163,7 @@ describe("Singleton", function () {
             })
           })
           it('should fail to withdraw again', async () => {
-            await expect(singleton.withdrawStake(AddressZero)).to.revertedWith('no unlocked stake')
+            await expect(entryPoint.withdrawStake(AddressZero)).to.revertedWith('no unlocked stake')
           })
         })
       })
@@ -174,50 +174,50 @@ describe("Singleton", function () {
     let wallet1: SimpleWallet
 
     before(async () => {
-      wallet1 = await new SimpleWallet__factory(ethersSigner).deploy(singleton.address, await walletOwner1.getAddress())
+      wallet1 = await new SimpleWallet__factory(ethersSigner).deploy(entryPoint.address, await walletOwner1.getAddress())
     })
     it('should fail on-chain', async () => {
-      const op = await fillAndSign({target: wallet1.address}, walletOwner1, singleton)
-      await expect(singleton.simulateWalletValidation(op)).to.revertedWith('must be called off-chain')
+      const op = await fillAndSign({sender: wallet1.address}, walletOwner1, entryPoint)
+      await expect(entryPoint.simulateWalletValidation(op)).to.revertedWith('must be called off-chain')
     });
-    it('should fail if payForSelfOp fails', async () => {
+    it('should fail if verifyUserOp fails', async () => {
       //using wrong owner for wallet1
-      const op = await fillAndSign({target: wallet1.address}, walletOwner, singleton)
-      await expect(singletonView.callStatic.simulateWalletValidation(op).catch(rethrow())).to
+      const op = await fillAndSign({sender: wallet1.address}, walletOwner, entryPoint)
+      await expect(entryPointView.callStatic.simulateWalletValidation(op).catch(rethrow())).to
         .revertedWith('wrong signature')
     });
-    it('should succeed if payForSelfOp succeeds', async () => {
-      const op = await fillAndSign({target: wallet1.address}, walletOwner1, singleton)
+    it('should succeed if verifyUserOp succeeds', async () => {
+      const op = await fillAndSign({sender: wallet1.address}, walletOwner1, entryPoint)
       await fund(wallet1)
-      const ret = await singletonView.callStatic.simulateWalletValidation(op).catch(rethrow())
+      const ret = await entryPointView.callStatic.simulateWalletValidation(op).catch(rethrow())
       console.log('   === simulate result', ret)
     });
-    it('should fail creation for wrong target', async () => {
+    it('should fail creation for wrong sender', async () => {
       const op1 = await fillAndSign({
-        initCode: WalletConstructor(singleton.address, walletOwner1.address),
-        target: '0x'.padEnd(42, '1')
-      }, walletOwner1, singleton)
-      await expect(singletonView.callStatic.simulateWalletValidation(op1).catch(rethrow()))
-        .to.revertedWith('target doesn\'t match create2 address')
+        initCode: WalletConstructor(entryPoint.address, walletOwner1.address),
+        sender: '0x'.padEnd(42, '1')
+      }, walletOwner1, entryPoint)
+      await expect(entryPointView.callStatic.simulateWalletValidation(op1).catch(rethrow()))
+        .to.revertedWith('sender doesn\'t match create2 address')
     })
 
     it('should succeed for creating a wallet', async () => {
       const op1 = await fillAndSign({
-        initCode: WalletConstructor(singleton.address, walletOwner1.address),
-      }, walletOwner1, singleton)
-      await fund(op1.target)
-      await singletonView.callStatic.simulateWalletValidation(op1).catch(rethrow())
+        initCode: WalletConstructor(entryPoint.address, walletOwner1.address),
+      }, walletOwner1, entryPoint)
+      await fund(op1.sender)
+      await entryPointView.callStatic.simulateWalletValidation(op1).catch(rethrow())
     })
 
     it('should not use banned ops during simulateWalletValidation', async () => {
       const op1 = await fillAndSign({
-        initCode: WalletConstructor(singleton.address, walletOwner1.address),
-      }, walletOwner1, singleton)
-      await fund(op1.target)
+        initCode: WalletConstructor(entryPoint.address, walletOwner1.address),
+      }, walletOwner1, entryPoint)
+      await fund(op1.sender)
       await fund(AddressZero)
       //we must create a real transaction to debug, and it must come from address zero:
       await ethers.provider.send('hardhat_impersonateAccount', [AddressZero])
-      const ret = await singletonView.simulateWalletValidation(op1)
+      const ret = await entryPointView.simulateWalletValidation(op1)
 
       await checkForBannedOps(ret!.hash)
     })
@@ -227,31 +227,31 @@ describe("Singleton", function () {
   describe('without paymaster (account pays in eth)', () => {
     describe('#handleOps', () => {
       let counter: TestCounter
-      let walletExecFromSingleton: PopulatedTransaction
+      let walletExecFromEntryPoint: PopulatedTransaction
       before(async () => {
 
         counter = await new TestCounter__factory(ethersSigner).deploy()
         const count = await counter.populateTransaction.count()
         const execCounterCount = await wallet.populateTransaction.exec(counter.address, count.data!)
-        walletExecFromSingleton = await wallet.populateTransaction.execFromSingleton(execCounterCount.data!)
+        walletExecFromEntryPoint = await wallet.populateTransaction.execFromEntryPoint(execCounterCount.data!)
       })
 
       it('wallet should pay for tx', async function () {
         const op = await fillAndSign({
-          target: wallet.address,
-          callData: walletExecFromSingleton.data,
+          sender: wallet.address,
+          callData: walletExecFromEntryPoint.data,
           verificationGas: 1e6,
           callGas: 1e6
-        }, walletOwner, singleton)
+        }, walletOwner, entryPoint)
         const redeemerAddress = Wallet.createRandom().address
 
         const countBefore = await counter.counters(wallet.address)
         //for estimateGas, must specify maxFeePerGas, otherwise our gas check fails
-        console.log('  == est gas=', await singleton.estimateGas.handleOps([op], redeemerAddress, {maxFeePerGas: 1e9}).then(tostr))
+        console.log('  == est gas=', await entryPoint.estimateGas.handleOps([op], redeemerAddress, {maxFeePerGas: 1e9}).then(tostr))
 
         //must specify at least on of maxFeePerGas, gasLimit
         // (gasLimit, to prevent estimateGas to fail on missing maxFeePerGas, see above..)
-        const rcpt = await singleton.handleOps([op], redeemerAddress, {
+        const rcpt = await entryPoint.handleOps([op], redeemerAddress, {
           maxFeePerGas: 1e9,
           gasLimit: 1e7
         }).then(t => t.wait())
@@ -260,7 +260,7 @@ describe("Singleton", function () {
         expect(countAfter.toNumber()).to.equal(countBefore.toNumber() + 1)
         console.log('rcpt.gasUsed=', rcpt.gasUsed.toString(), rcpt.transactionHash)
 
-        await calcGasUsage(rcpt, singleton, redeemerAddress)
+        await calcGasUsage(rcpt, entryPoint, redeemerAddress)
 
       });
 
@@ -268,19 +268,19 @@ describe("Singleton", function () {
         const redeemerAddress = Wallet.createRandom().address
 
         const op = await fillAndSign({
-          target: wallet.address,
-          callData: walletExecFromSingleton.data,
-        }, walletOwner, singleton)
+          sender: wallet.address,
+          callData: walletExecFromEntryPoint.data,
+        }, walletOwner, entryPoint)
 
         const countBefore = await counter.counters(wallet.address)
-        const rcpt = await singleton.handleOp(op, redeemerAddress, {
+        const rcpt = await entryPoint.handleOp(op, redeemerAddress, {
           gasLimit: 1e7
         }).then(t => t.wait())
         const countAfter = await counter.counters(wallet.address)
         expect(countAfter.toNumber()).to.equal(countBefore.toNumber() + 1)
 
         console.log('rcpt.gasUsed=', rcpt.gasUsed.toString(), rcpt.transactionHash)
-        await calcGasUsage(rcpt, singleton, redeemerAddress)
+        await calcGasUsage(rcpt, entryPoint, redeemerAddress)
 
       });
     })
@@ -290,60 +290,60 @@ describe("Singleton", function () {
       let created = false
       let redeemerAddress = Wallet.createRandom().address //1
 
-      it('should reject create if target address is wrong', async () => {
+      it('should reject create if sender address is wrong', async () => {
 
         const op = await fillAndSign({
-          initCode: WalletConstructor(singleton.address, walletOwner.address),
+          initCode: WalletConstructor(entryPoint.address, walletOwner.address),
           verificationGas: 2e6,
-          target: '0x'.padEnd(42, '1')
-        }, walletOwner, singleton)
+          sender: '0x'.padEnd(42, '1')
+        }, walletOwner, entryPoint)
 
-        await expect(singleton.callStatic.handleOps([op], redeemerAddress, {
+        await expect(entryPoint.callStatic.handleOps([op], redeemerAddress, {
           gasLimit: 1e7
-        })).to.revertedWith('target doesn\'t match create2 address')
+        })).to.revertedWith('sender doesn\'t match create2 address')
       });
 
       it('should reject create if account not funded', async () => {
 
         const op = await fillAndSign({
-          initCode: WalletConstructor(singleton.address, walletOwner.address),
+          initCode: WalletConstructor(entryPoint.address, walletOwner.address),
           verificationGas: 2e6
-        }, walletOwner, singleton)
+        }, walletOwner, entryPoint)
 
-        expect(await ethers.provider.getBalance(op.target)).to.eq(0)
+        expect(await ethers.provider.getBalance(op.sender)).to.eq(0)
 
-        await expect(singleton.callStatic.handleOps([op], redeemerAddress, {
+        await expect(entryPoint.callStatic.handleOps([op], redeemerAddress, {
           gasLimit: 1e7
         })).to.revertedWith('didn\'t pay prefund')
 
-        // await expect(await ethers.provider.getCode(op.target).then(x => x.length)).to.equal(2, "wallet exists before creation")
+        // await expect(await ethers.provider.getCode(op.sender).then(x => x.length)).to.equal(2, "wallet exists before creation")
       });
 
       it('should succeed to create account after prefund', async () => {
 
-        const preAddr = await singleton.getAccountAddress(WalletConstructor(singleton.address, walletOwner.address), 0)
+        const preAddr = await entryPoint.getAccountAddress(WalletConstructor(entryPoint.address, walletOwner.address), 0)
         await fund(preAddr)
         createOp = await fillAndSign({
-          initCode: WalletConstructor(singleton.address, walletOwner.address),
+          initCode: WalletConstructor(entryPoint.address, walletOwner.address),
           callGas: 1e7,
           verificationGas: 2e6
 
-        }, walletOwner, singleton)
+        }, walletOwner, entryPoint)
 
         await expect(await ethers.provider.getCode(preAddr).then(x => x.length)).to.equal(2, "wallet exists before creation")
-        const rcpt = await singleton.handleOps([createOp], redeemerAddress, {
+        const rcpt = await entryPoint.handleOps([createOp], redeemerAddress, {
           gasLimit: 1e7,
         }).then(tx => tx.wait()).catch(rethrow())
         created = true
-        await calcGasUsage(rcpt!, singleton, redeemerAddress)
+        await calcGasUsage(rcpt!, entryPoint, redeemerAddress)
       });
 
       it('should reject if account already created', async function () {
-        const preAddr = await singleton.getAccountAddress(WalletConstructor(singleton.address, walletOwner.address), 0)
+        const preAddr = await entryPoint.getAccountAddress(WalletConstructor(entryPoint.address, walletOwner.address), 0)
         if (await ethers.provider.getCode(preAddr).then(x => x.length) == 2)
           this.skip()
 
-        await expect(singleton.callStatic.handleOps([createOp], redeemerAddress, {
+        await expect(entryPoint.callStatic.handleOps([createOp], redeemerAddress, {
           gasLimit: 1e7
         })).to.revertedWith('create2 failed')
       });
@@ -357,7 +357,7 @@ describe("Singleton", function () {
        *    (wallet created in advance)
        */
       let counter: TestCounter
-      let walletExecCounterFromSingleton: PopulatedTransaction
+      let walletExecCounterFromEntryPoint: PopulatedTransaction
       const redeemerAddress = Wallet.createRandom().address
       const walletOwner1 = createWalletOwner()
       let wallet1: string
@@ -370,37 +370,37 @@ describe("Singleton", function () {
         counter = await new TestCounter__factory(ethersSigner).deploy()
         const count = await counter.populateTransaction.count()
         const execCounterCount = await wallet.populateTransaction.exec(counter.address, count.data!)
-        walletExecCounterFromSingleton = await wallet.populateTransaction.execFromSingleton(execCounterCount.data!)
-        wallet1 = await singleton.getAccountAddress(WalletConstructor(singleton.address, walletOwner1.address), 0)
-        wallet2 = await new SimpleWallet__factory(ethersSigner).deploy(singleton.address, walletOwner2.address)
+        walletExecCounterFromEntryPoint = await wallet.populateTransaction.execFromEntryPoint(execCounterCount.data!)
+        wallet1 = await entryPoint.getAccountAddress(WalletConstructor(entryPoint.address, walletOwner1.address), 0)
+        wallet2 = await new SimpleWallet__factory(ethersSigner).deploy(entryPoint.address, walletOwner2.address)
         await fund(wallet1)
         await fund(wallet2.address)
         //execute and incremtn counter
         const op1 = await fillAndSign({
-          initCode: WalletConstructor(singleton.address, walletOwner1.address),
-          callData: walletExecCounterFromSingleton.data,
+          initCode: WalletConstructor(entryPoint.address, walletOwner1.address),
+          callData: walletExecCounterFromEntryPoint.data,
           callGas: 2e6,
           verificationGas: 2e6
-        }, walletOwner1, singleton)
+        }, walletOwner1, entryPoint)
 
         // console.log('op=', {...op1, callData: op1.callData.length, initCode: op1.initCode.length})
 
         const op2 = await fillAndSign({
-          callData: walletExecCounterFromSingleton.data,
-          target: wallet2.address,
+          callData: walletExecCounterFromEntryPoint.data,
+          sender: wallet2.address,
           callGas: 2e6,
           verificationGas: 76000,
-        }, walletOwner2, singleton)
+        }, walletOwner2, entryPoint)
 
-        const estim = await singletonView.callStatic.simulateWalletValidation(op2, {gasPrice: 1e9})
-        const estim1 = await singletonView.simulatePaymasterValidation(op2, estim!, {gasPrice: 1e9})
+        const estim = await entryPointView.callStatic.simulateWalletValidation(op2, {gasPrice: 1e9})
+        const estim1 = await entryPointView.simulatePaymasterValidation(op2, estim!, {gasPrice: 1e9})
         const verificationGas = estim.add(estim1.gasUsedByPayForOp)
 
-        await fund(op1.target)
+        await fund(op1.sender)
         await fund(wallet2.address)
         prebalance1 = await ethers.provider.getBalance((wallet1))
         prebalance2 = await ethers.provider.getBalance((wallet2.address))
-        await singleton.handleOps([op1!, op2], redeemerAddress).catch((rethrow())).then(r => r!.wait())
+        await entryPoint.handleOps([op1!, op2], redeemerAddress).catch((rethrow())).then(r => r!.wait())
         // console.log(ret.events!.map(e=>({ev:e.event, ...objdump(e.args!)})))
       })
       it('should execute', async () => {

--- a/test/testutils.ts
+++ b/test/testutils.ts
@@ -4,7 +4,7 @@ import {Contract, ContractReceipt, Wallet} from "ethers";
 import {IERC20} from '../typechain'
 import {BytesLike} from "@ethersproject/bytes";
 import {
-  Singleton,
+  EntryPoint,
   SimpleWallet__factory
 } from "../typechain";
 import {expect} from "chai";
@@ -60,9 +60,9 @@ export function callDataCost(data: string): number {
     .reduce((sum, x) => sum + x)
 }
 
-export async function calcGasUsage(rcpt: ContractReceipt, singleton: Singleton, redeemerAddress?: string) {
+export async function calcGasUsage(rcpt: ContractReceipt, entryPoint: EntryPoint, redeemerAddress?: string) {
   const actualGas = await rcpt.gasUsed
-  const logs = await singleton.queryFilter(singleton.filters.UserOperationEvent(), rcpt.blockHash)
+  const logs = await entryPoint.queryFilter(entryPoint.filters.UserOperationEvent(), rcpt.blockHash)
   const {actualGasCost, actualGasPrice} = logs[0].args
   console.log('\t== actual gasUsed (from tx receipt)=', actualGas.toString())
   let calculatedGasUsed = actualGasCost.toNumber() / actualGasPrice.toNumber();
@@ -75,8 +75,8 @@ export async function calcGasUsage(rcpt: ContractReceipt, singleton: Singleton, 
 }
 
 //helper function to create a constructor call to our wallet.
-export function WalletConstructor(singleton: string, owner: string): BytesLike {
-  return new SimpleWallet__factory().getDeployTransaction(singleton, owner).data!
+export function WalletConstructor(entryPoint: string, owner: string): BytesLike {
+  return new SimpleWallet__factory().getDeployTransaction(entryPoint, owner).data!
 }
 
 const panicCodes: { [key: string]: any } = {


### PR DESCRIPTION
Singleton=>EntryPoint
target=>sender
payForSelfOp => validateUserOp
payForOp => validatePaymasterUserOp
added preVerificationGas

removed execFromSingleton from interface (it is required by actual implementation, but actual signature is wallet-specific)