### PR TITLE
basefee legacy support

### DIFF
--- a/contracts/UserOperation.sol
+++ b/contracts/UserOperation.sol
@@ -25,7 +25,13 @@ library UserOperationLib {
     // pay above what he signed for.
     function gasPrice(UserOperation calldata userOp) internal view returns (uint) {
     unchecked {
-        return min(userOp.maxFeePerGas, userOp.maxPriorityFeePerGas + block.basefee);
+        uint maxFeePerGas = userOp.maxFeePerGas;
+        uint maxPriorityFeePerGas = userOp.maxPriorityFeePerGas;
+        if (maxFeePerGas == maxPriorityFeePerGas) {
+            //legacy mode (for networks that don't support basefee opcode
+            return maxFeePerGas;
+        }
+        return min(maxFeePerGas, maxPriorityFeePerGas + block.basefee);
     }
     }
 


### PR DESCRIPTION
for blockchain that don't support `basefee` opcode:
set `maxFeePerGas = maxPriorityFeePerGas = gasPrice`
this is just the legacy mode of eip1559: in this case, there is no need to execute the "basefee" opcode at all.