### PR TITLE
Deposit paymaster

### DIFF
--- a/contracts/samples/DepositPaymaster.sol
+++ b/contracts/samples/DepositPaymaster.sol
@@ -1,0 +1,117 @@
+// SPDX-License-Identifier: GPL-3.0
+pragma solidity ^0.8.7;
+
+import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import "@openzeppelin/contracts/access/Ownable.sol";
+import "../BasePaymaster.sol";
+
+interface IOracle {
+
+    /**
+     * return amount of tokens that are required to receive that much eth.
+     */
+    function getTokenToEthOutputPrice(uint ethOutput) external view returns (uint);
+}
+
+/**
+ * A token-based paymaster that accepts token deposit
+ * The deposit is only a safeguard: the user pays with his token balance.
+ *  only if the user didn't approve() the paymaster, or if the token balance is not enough, the deposit will be used.
+ *  thus the required deposit is to cover just one method call.
+ *
+ * paymasterData holds the token to use.
+*/
+contract DepositPaymaster is BasePaymaster {
+
+    IOracle constant nullOracle = IOracle(address(0));
+    mapping(IERC20 => IOracle) public oracles;
+    mapping(IERC20 => mapping(address => uint)) public balances;
+    mapping(address => uint) unlockBlock;
+
+    constructor(EntryPoint _entryPoint) BasePaymaster(_entryPoint) {}
+
+    /**
+     * owner of the paymaster should add supported tokens
+     */
+    function addToken(IERC20 token, IOracle tokenPriceOracle) external onlyOwner {
+        require(oracles[token] == nullOracle);
+        oracles[token] = tokenPriceOracle;
+    }
+
+    /**
+     * approve owner-selected address to withdraw collected tokens.
+     */
+    function approve(IERC20 token, address target, uint amount) external onlyOwner {
+        token.approve(target, amount);
+    }
+
+    /**
+     * deposit tokens that a specific account can use to pay for gas.
+     * The sender must first approve this paymaster to withdraw these tokens (they are only withdrawn in this method).
+     * Note depositing the tokens is equivalent to transferring them to the "account" - only the account can later
+     *  use them - either as gas, or using withdrawTo()
+     *
+     * @param token the token to deposit.
+     * @param account the account to deposit for.
+     * @param amount the amount of token to deposit.
+     */
+    function addDepositFor(IERC20 token, address account, uint amount) external {
+        //(sender must have approval for the paymaster)
+        token.transferFrom(msg.sender, address(this), amount);
+        require(oracles[token] != nullOracle, "unsupported token");
+        balances[token][account] += amount;
+        if (msg.sender == account) {
+            lockDeposit();
+        }
+    }
+
+    /**
+     * unlock deposit, so that it can be withdrawn.
+     * can't be called on in the same block as withdrawTo()
+     */
+    function unlockDeposit() external {
+        unlockBlock[msg.sender] = block.number;
+    }
+
+    /**
+     * lock the tokens deposited for this account so they can be used to pay for gas.
+     * after calling unlock(), the account can't use this paymaster until the deposit is locked.
+     */
+    function lockDeposit() public {
+        unlockBlock[msg.sender] = 0;
+    }
+
+    /**
+     * withdraw tokens.
+     * can only be called after unlock() is called in a previous block.
+     */
+    function withdrawTo(IERC20 token, address target, uint amount) public {
+        require(unlockBlock[msg.sender] != 0 && block.number > unlockBlock[msg.sender]);
+        balances[token][msg.sender] -= amount;
+        token.transfer(target, amount);
+    }
+
+    function validatePaymasterUserOp(UserOperation calldata userOp, bytes32 requestId, uint maxCost)
+    external view override returns (bytes memory context) {
+
+        (requestId);
+        require(userOp.paymasterData.length == 32, "DepositPaymaster: paymasterData must specify token");
+        IERC20 token = abi.decode(userOp.paymasterData, (IERC20));
+        IOracle oracle = oracles[token];
+        require(oracle != nullOracle, "DepositPaymaster: unsupported token in paymasterData");
+        address account = userOp.sender;
+        uint maxTokenCost = oracle.getTokenToEthOutputPrice(maxCost);
+        require(unlockBlock[account] == 0, "not locked");
+        require(balances[token][account] >= maxTokenCost);
+        return abi.encode(account, token, maxTokenCost, maxCost);
+    }
+
+    function _postOp(PostOpMode mode, bytes calldata context, uint actualGasCost) internal override {
+        (mode);
+
+        (address account, IERC20 token, uint maxTokenCost, uint maxCost) = abi.decode(context, (address, IERC20, uint, uint));
+        //use same conversion rate as used for validation.
+        uint actualTokenCost = actualGasCost * maxTokenCost / maxCost;
+        balances[token][account] -= actualTokenCost;
+    }
+}

--- a/contracts/samples/SimpleWallet.sol
+++ b/contracts/samples/SimpleWallet.sol
@@ -125,7 +125,7 @@ contract SimpleWallet is IWallet {
         require(req);
     }
 
-    function withdrawDepsitTo(address payable withdrawAddress, uint amount) public {
+    function withdrawDepositTo(address payable withdrawAddress, uint amount) public onlyOwner{
         entryPoint.withdrawTo(withdrawAddress, amount);
     }
 }

--- a/contracts/samples/SimpleWallet.sol
+++ b/contracts/samples/SimpleWallet.sol
@@ -56,6 +56,13 @@ contract SimpleWallet is IWallet {
         _call(dest, value, func);
     }
 
+    function execBatch(address[] calldata dest, bytes[] calldata func) external onlyOwner {
+        require(dest.length == func.length, "wrong array lengths");
+        for (uint i = 0; i < dest.length; i++) {
+            _call(dest[i], 0, func[i]);
+        }
+    }
+
     function updateEntryPoint(EntryPoint _entryPoint) external onlyOwner {
         emit EntryPointChanged(entryPoint, _entryPoint);
         entryPoint = _entryPoint;
@@ -103,7 +110,7 @@ contract SimpleWallet is IWallet {
         (bool success, bytes memory result) = sender.call{value : value}(data);
         if (!success) {
             assembly {
-                revert(result, add(result, 32))
+                revert(add(result,32), mload(result))
             }
         }
     }

--- a/contracts/samples/TestOracle.sol
+++ b/contracts/samples/TestOracle.sol
@@ -5,7 +5,7 @@ import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
 import "./DepositPaymaster.sol";
 
 contract TestOracle is IOracle {
-    function getTokenToEthOutputPrice(uint ethOutput) external view override returns (uint tokenInput) {
+    function getTokenToEthOutputPrice(uint ethOutput) external pure override returns (uint tokenInput) {
         return ethOutput * 2;
     }
 }

--- a/contracts/samples/TestOracle.sol
+++ b/contracts/samples/TestOracle.sol
@@ -1,0 +1,11 @@
+// SPDX-License-Identifier: GPL-3.0
+pragma solidity ^0.8.7;
+
+import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+import "./DepositPaymaster.sol";
+
+contract TestOracle is IOracle {
+    function getTokenToEthOutputPrice(uint ethOutput) external view override returns (uint tokenInput) {
+        return ethOutput * 2;
+    }
+}

--- a/contracts/samples/VerifyingPaymaster.sol
+++ b/contracts/samples/VerifyingPaymaster.sol
@@ -26,7 +26,7 @@ contract VerifyingPaymaster is BasePaymaster {
     }
 
     // return the hash we're going to sign off-chain (and validate on-chain)
-    function getHash(UserOperation calldata userOp) public view returns (bytes32) {
+    function getHash(UserOperation calldata userOp) public pure returns (bytes32) {
         //can't use userOp.hash(), since it contains also the paymasterData itself.
         return keccak256(abi.encode(
                 userOp.sender,

--- a/test/deposit-paymaster.test.ts
+++ b/test/deposit-paymaster.test.ts
@@ -1,0 +1,213 @@
+import './aa.init'
+import {describe} from 'mocha'
+import {Wallet} from "ethers";
+import {ethers} from "hardhat";
+import {expect} from "chai";
+import {
+  SimpleWallet,
+  SimpleWallet__factory,
+  EntryPoint,
+  DepositPaymaster,
+  DepositPaymaster__factory,
+  TestOracle__factory,
+  TestCounter,
+  TestCounter__factory,
+  TestToken,
+  TestToken__factory
+} from "../typechain";
+import {
+  AddressZero,
+  createWalletOwner,
+  deployEntryPoint, FIVE_ETH, ONE_ETH, TWO_ETH
+} from "./testutils";
+import {fillAndSign} from "./UserOp";
+import {hexZeroPad, parseEther} from "ethers/lib/utils";
+import exp from "constants";
+
+describe("DepositPaymaster", async () => {
+
+  let entryPoint: EntryPoint
+  let entryPointStatic: EntryPoint
+  let ethersSigner = ethers.provider.getSigner();
+  let offchainSigner: Wallet
+  let token: TestToken
+  let paymaster: DepositPaymaster
+  before(async function () {
+
+    entryPoint = await deployEntryPoint(0, 0)
+    entryPointStatic = entryPoint.connect(AddressZero)
+
+    offchainSigner = createWalletOwner()
+
+    paymaster = await new DepositPaymaster__factory(ethersSigner).deploy(entryPoint.address)
+    paymaster.addStake(0, {value: parseEther('2')})
+
+    token = await new TestToken__factory(ethersSigner).deploy()
+    const testOracle = await new TestOracle__factory(ethersSigner).deploy()
+    await paymaster.addToken(token.address, testOracle.address)
+
+    await token.mint(await ethersSigner.getAddress(), FIVE_ETH)
+    await token.approve(paymaster.address, ethers.constants.MaxUint256)
+  })
+
+  describe('deposit', () => {
+    let wallet: SimpleWallet
+
+    before(async () => {
+      wallet = await new SimpleWallet__factory(ethersSigner).deploy(entryPoint.address, await ethersSigner.getAddress())
+    })
+    it('should deposit and read balance', async () => {
+      await paymaster.addDepositFor(token.address, wallet.address, 100)
+      expect(await paymaster.depositInfo(token.address, wallet.address)).to.eql({amount:100})
+    });
+    it('should fail to withdraw without unlock', async () => {
+      const paymasterWithdraw = await paymaster.populateTransaction.withdrawTokensTo(token.address, AddressZero, 1).then(tx => tx.data!)
+
+      await expect(
+        wallet.exec(paymaster.address, 0, paymasterWithdraw)
+      ).to.revertedWith('DepositPaymaster: must unlockTokenDeposit')
+    });
+    it('should fail to withdraw within the same block ', async () => {
+      const paymasterUnlock = await paymaster.populateTransaction.unlockTokenDeposit().then(tx => tx.data!)
+      const paymasterWithdraw = await paymaster.populateTransaction.withdrawTokensTo(token.address, AddressZero, 1).then(tx => tx.data!)
+
+      await expect(
+        wallet.execBatch([paymaster.address, paymaster.address], [paymasterUnlock, paymasterWithdraw])
+      ).to.be.revertedWith('DepositPaymaster: must unlockTokenDeposit')
+    });
+    it('should succeed to withdraw after unlock', async () => {
+      const paymasterUnlock = await paymaster.populateTransaction.unlockTokenDeposit().then(tx => tx.data!)
+      const target = createWalletOwner().address
+      const paymasterWithdraw = await paymaster.populateTransaction.withdrawTokensTo(token.address, target, 1).then(tx => tx.data!)
+      await wallet.exec(paymaster.address, 0, paymasterUnlock)
+      await wallet.exec(paymaster.address, 0, paymasterWithdraw)
+      expect(await token.balanceOf(target)).to.eq(1)
+    });
+  })
+
+  describe('#validatePaymasterUserOp', () => {
+    let wallet: SimpleWallet
+    const gasPrice = 1e9
+    let walletOwner: string
+
+    before(async () => {
+      walletOwner = await ethersSigner.getAddress();
+      wallet = await new SimpleWallet__factory(ethersSigner).deploy(entryPoint.address, walletOwner)
+    })
+
+    it('should fail if no token', async () => {
+      const userOp = await fillAndSign({
+        sender: wallet.address,
+        paymaster: paymaster.address,
+      }, ethersSigner, entryPoint)
+      await expect(entryPointStatic.callStatic.simulateValidation(userOp)).to.be.revertedWith('paymasterData must specify token')
+    });
+
+    it('should fail with wrong', async () => {
+      const userOp = await fillAndSign({
+        sender: wallet.address,
+        paymaster: paymaster.address,
+        paymasterData: hexZeroPad('0x1234', 32),
+      }, ethersSigner, entryPoint)
+      await expect(entryPointStatic.callStatic.simulateValidation(userOp, {gasPrice})).to.be.revertedWith('DepositPaymaster: unsupported token in paymasterData')
+    });
+
+    it('should reject if no deposit', async () => {
+      const userOp = await fillAndSign({
+        sender: wallet.address,
+        paymaster: paymaster.address,
+        paymasterData: hexZeroPad(token.address, 32)
+      }, ethersSigner, entryPoint)
+      await expect(entryPointStatic.callStatic.simulateValidation(userOp, {gasPrice})).to.be.revertedWith('DepositPaymaster: deposit too low')
+    });
+
+    it('should reject if deposit is not locked', async () => {
+      await paymaster.addDepositFor(token.address, wallet.address, 1e6)
+
+      const paymasterUnlock = await paymaster.populateTransaction.unlockTokenDeposit().then(tx => tx.data!)
+      await wallet.exec(paymaster.address, 0, paymasterUnlock)
+
+      const userOp = await fillAndSign({
+        sender: wallet.address,
+        paymaster: paymaster.address,
+        paymasterData: hexZeroPad(token.address, 32)
+      }, ethersSigner, entryPoint)
+      await expect(entryPointStatic.callStatic.simulateValidation(userOp, {gasPrice})).to.be.revertedWith('not locked')
+    })
+
+    it('succeed with valid deposit', async () => {
+      // needed only if previous test did unlock..
+      const paymasterLockTokenDeposit = await paymaster.populateTransaction.lockTokenDeposit().then(tx => tx.data!)
+      await wallet.exec(paymaster.address, 0, paymasterLockTokenDeposit)
+
+      const userOp = await fillAndSign({
+        sender: wallet.address,
+        paymaster: paymaster.address,
+        paymasterData: hexZeroPad(token.address, 32)
+      }, ethersSigner, entryPoint)
+      await entryPointStatic.callStatic.simulateValidation(userOp)
+    });
+  })
+  describe('#handleOps', () => {
+    let wallet: SimpleWallet
+    const walletOwner = createWalletOwner()
+    let counter: TestCounter
+    let callData: string
+    before(async () => {
+      wallet = await new SimpleWallet__factory(ethersSigner).deploy(entryPoint.address, walletOwner.address)
+      counter = await new TestCounter__factory(ethersSigner).deploy()
+      const counterJustEmit = await counter.populateTransaction.justemit().then(tx => tx.data!)
+      callData = await wallet.populateTransaction.execFromEntryPoint(counter.address, 0, counterJustEmit).then(tx => tx.data!)
+
+      await paymaster.addDepositFor(token.address, wallet.address, ONE_ETH)
+    })
+    it('should pay with deposit (and revert user\'s call) if user can\'t pay with tokens', async () => {
+
+      const beneficiary = createWalletOwner().address
+      const userOp = await fillAndSign({
+        sender: wallet.address,
+        paymaster: paymaster.address,
+        paymasterData: hexZeroPad(token.address, 32),
+        callData
+      }, walletOwner, entryPoint)
+
+      await entryPoint.handleOp(userOp, beneficiary)
+      const [log] = await entryPoint.queryFilter(entryPoint.filters.UserOperationEvent())
+      expect(log.args.success).to.eq(false)
+      expect(await counter.queryFilter(counter.filters.CalledFrom())).to.eql([])
+      expect(await ethers.provider.getBalance(beneficiary)).to.be.gt(0)
+    });
+    it('should pay with tokens if available', async () => {
+      const beneficiary = createWalletOwner().address
+      let initialTokens = parseEther('1')
+      await token.mint(wallet.address, initialTokens)
+
+      //need to "approve" the paymaster to use the tokens. we issue a UserOp for that (which uses the deposit to execute)
+      const tokenApprovePaymaster = await token.populateTransaction.approve(paymaster.address, ethers.constants.MaxUint256).then(tx=>tx.data!)
+      const execApprove = await wallet.populateTransaction.execFromEntryPoint(token.address, 0, tokenApprovePaymaster).then(tx=>tx.data!)
+      const userOp1 = await fillAndSign({
+        sender: wallet.address,
+        paymaster: paymaster.address,
+        paymasterData: hexZeroPad(token.address, 32),
+        callData: execApprove
+      }, walletOwner, entryPoint)
+      await entryPoint.handleOp(userOp1, AddressZero)
+
+
+      const userOp = await fillAndSign({
+        sender: wallet.address,
+        paymaster: paymaster.address,
+        paymasterData: hexZeroPad(token.address, 32),
+        callData
+      }, walletOwner, entryPoint)
+      await entryPoint.handleOp(userOp, beneficiary)
+      const [log] = await entryPoint.queryFilter(entryPoint.filters.UserOperationEvent(), await ethers.provider.getBlockNumber())
+      expect(log.args.success).to.eq(true)
+      const charge = log.args.actualGasCost
+      expect(await ethers.provider.getBalance(beneficiary)).to.eq(charge)
+
+      let targetLogs = await counter.queryFilter(counter.filters.CalledFrom());
+      expect(targetLogs.length).to.eq(1)
+    });
+  })
+})

--- a/test/entrypoint.test.ts
+++ b/test/entrypoint.test.ts
@@ -215,7 +215,7 @@ describe("EntryPoint", function () {
         await expect(entryPoint.connect(wallet.address).callStatic.unstakeDeposit()).to.revertedWith('not staked')
       })
       it('should withdraw with no unlock', async () => {
-        await wallet.withdrawDepsitTo(wallet.address, ONE_ETH)
+        await wallet.withdrawDepositTo(wallet.address, ONE_ETH)
         expect(await getBalance(wallet.address)).to.equal(1e18)
       })
     })

--- a/test/z-batch.test.ts
+++ b/test/z-batch.test.ts
@@ -47,11 +47,7 @@ describe("Batch gas testing", function () {
 
   let results: (() => void)[] = []
   before(async function () {
-
-    //this test is currently useless. client need to do better work with preVerificationGas calculation.
-    // we do need a better recommendation for bundlers how to validate those values before accepting a request.
     this.skip()
-    return
 
     await checkForGeth()
     testUtil = await new TestUtil__factory(ethersSigner).deploy()


### PR DESCRIPTION
## DepositPaymaster

A paymaster that works with token deposits
- request contains a token address in its "paymasterData" 
- paymaster has an "Oracle" for token to eth (see below)
- wallet must have a "security deposit" covering maxGasCost
- the deposit is NOT used for normal transactions: the paymaster uses `token.transferFrom(wallet, paymaster)` to pay.
- if the above payment fails (no tokens or no approval), the transaction gets reverted, and the paymaster uses the deposit to compensate itself.
- the wallet can withdraw its deposit (using `withdrawDepositTo()`) - but it must first call `unlockDeposit()` un a separate transaction. This prevents the wallet from withdrawing the deposit within a UserOperation that uses this paymaster.

## About the Oracle
- The oracle exposes a single view function to return the gas cost in tokens.
- Due to the limitations of AccountAbstraction V1, this paymaster cannot access storage outside of its own contract, unless explicitly whitelisted by miners.
- (Note that technically anyone can call `EntryPoint.handleOps()`, so a transaction that uses the paymaster can be executed - just not by the standard miners.