### PR TITLE
Add getSenderStorage

### DIFF
--- a/contracts/EntryPoint.sol
+++ b/contracts/EntryPoint.sol
@@ -353,5 +353,21 @@ contract EntryPoint is StakeManager {
     function isPaymasterStaked(address paymaster, uint stake) public view returns (bool) {
         return isStaked(paymaster, stake, unstakeDelaySec);
     }
+
+    /**
+     * return the storage cells used internally by the EntryPoint for this sender address.
+     * During `simulateValidation`, allow these storage cells to be accessed
+     *  (that is, a wallet/paymaster are allowed to access EntryPoint's storage related to this wallet, but no other)
+     */
+    function getSenderStorage(address sender) external view returns (uint[] memory senderStorageCells) {
+        uint cell;
+        DepositInfo storage info = deposits[sender];
+
+        assembly {
+            cell := info.slot
+        }
+        senderStorageCells = new uint[](1);
+        senderStorageCells[0] = cell;
+    }
 }
 

--- a/test/entrypoint.test.ts
+++ b/test/entrypoint.test.ts
@@ -97,6 +97,12 @@ describe("EntryPoint", function () {
       before(async () => {
         await entryPoint.addStakeTo(signer, 2, {value: TWO_ETH})
       })
+      it( 'getStorageStake() should get storage cell', async() => {
+        const cells = await entryPoint.getSenderStorage(signer)
+        const val = await ethers.provider.getStorageAt(entryPoint.address, cells[0])
+        const mask = BigNumber.from(2).pow(112).sub(1)
+        expect(BigNumber.from(val).and(mask)).to.eq(TWO_ETH)
+      })
       it('should report "staked" state', async () => {
         expect(await entryPoint.isPaymasterStaked(addr, 0)).to.eq(true)
         const {amount, unstakeDelaySec, withdrawTime} = await entryPoint.getDepositInfo(addr)


### PR DESCRIPTION
return the storage cells in the entrypoint the sender is allowed to
access during simulation