### PR TITLE
Clarify wallet factory behavior when the wallet already exists

### DIFF
--- a/eip/EIPS/eip-4337.md
+++ b/eip/EIPS/eip-4337.md
@@ -443,6 +443,7 @@ The wallet creation itself is done by a "factory" contract, with wallet-specific
 The factory is expected to use CREATE2 (not CREATE) to create the wallet, so that the order of creation of wallets doesn't interfere with the generated addresses.
 The `initCode` field (if non-zero length) is parsed as a 20-byte address, followed by "calldata" to pass to this address.
 This method call is expected to create a wallet and return its address.
+If the factory does use CREATE2 or some other deterministic method to create the wallet, it's expected to return the wallet address even if the wallet has already been created.  This is to make it easier for clients to query the address without knowing if the wallet has already been deployed, by simulating a call to `entryPoint.getSenderAddress()`, which calls the factory under the hood.
 When `initCode` is specified, if either the `sender` address points to an existing contract, or (after calling the initCode) the `sender` address still does not exist,
 then the operation is aborted.
 The `initCode` MUST NOT be called directly from the entryPoint, but from another address.
@@ -451,7 +452,7 @@ For security reasons, it is important that the generated contract address will d
 This way, even if someone can create a wallet at that address, he can't set different credentials to control it.
 
 NOTE: In order for the wallet to determine the "counterfactual" address of the wallet (prior its creation), 
-it should make a static call to the `entryPoint.createSender()`
+it should make a static call to the `entryPoint.getSenderAddress()`
 
 ### Entry point upgrading
 


### PR DESCRIPTION
Currently, when a wallet already exists, it's not clear if [`entryPoint.getSenderAddress()`](https://github.com/eth-infinitism/account-abstraction/blob/699ecca1770f7e561bbc01e4e15e30ce2a50ebcb/contracts/core/EntryPoint.sol#L289-L292) will revert or not, since that depends on the internal logic of the wallet factory.  For example, if the factory is [`SimpleWalletDeployer`](https://github.com/eth-infinitism/account-abstraction/blob/699ecca1770f7e561bbc01e4e15e30ce2a50ebcb/contracts/samples/SimpleWalletDeployer.sol), `getSenderAddress()` reverts because `SimpleWalletDeployer` reverts if the wallet already exists.

I'm updating the spec to clarify that the wallet factory should return the address even if the wallet already exists, since that's more friendly to clients who don't want to keep track of deployed wallet addresses, such as the [`SimpleWallet` client](https://github.com/eth-infinitism/bundler/blob/d5071dbfb22206f013b7b28ee188afa546265897/packages/sdk/src/SimpleWalletAPI.ts).