### PR TITLE
Fix runop script; Rename SimpleWallet to SimpleAccount

### DIFF
--- a/.solcover.js
+++ b/.solcover.js
@@ -4,6 +4,6 @@ module.exports = {
     "bls/lib",
     //solc-coverage fails to compile our Manager module.
     "gnosis",
-    "samples/SimpleWalletForTokens.sol"
+    "samples/SimpleAccountForTokens.sol"
   ],
 };

--- a/deploy/deploy_entrypoint.ts
+++ b/deploy/deploy_entrypoint.ts
@@ -19,14 +19,14 @@ const deployEntryPoint: DeployFunction = async function (hre: HardhatRuntimeEnvi
   const entryPointAddress = ret.address
 
   const w = await hre.deployments.deploy(
-    'SimpleWallet', {
+    'SimpleAccount', {
       from,
       args: [entryPointAddress, from],
       gasLimit: 2e6,
       deterministicDeployment: true
     })
 
-  console.log('== wallet=', w.address)
+  console.log('==account=', w.address)
 
   const t = await hre.deployments.deploy('TestCounter', {
     from,


### PR DESCRIPTION
Hi. I was trying to follow the docs here [https://eip4337.com/en/latest/usage.html](https://eip4337.com/en/latest/usage.html) but couldn't run the `runop` script because we were missing the `SimpleWallet` contract. 

I fixed the script by updating `SimpleWallet` to `SimpleAccount`. Now, the script runs as expected and doesn't throw any errors.