### PR TITLE
AA-94 update keccak rules.

### DIFF
--- a/eip/EIPS/eip-4337.md
+++ b/eip/EIPS/eip-4337.md
@@ -313,9 +313,9 @@ In solidity, this includes all storage of the contract itself, and any storage o
 An address `A` is associated with:
 1. Slots of contract `A` address itself.
 2. Slot `A` on any other address.
-3. Slots of type `keccak256(A || X)` on any other address. (to cover `mapping(address => value)`, which is usually used for balance in ERC20 tokens).
-4. Slots of type `keccak256(X || OWN)` on any other address, where OWN is some slot of the previous (third) type, or recursively of this (forth) type
-  (to cover `mapping(address ⇒ mapping(address ⇒ uint256)`) that are usually used for `allowances` in ERC20 tokens).
+3. Slots of type `keccak256(A || X) + n` on any other address. (to cover `mapping(address => value)`, which is usually used for balance in ERC20 tokens).
+   `n` is an offset value up to 128, to allow accessing fields in the format `mapping(address => struct)`
+
 
 #### Alternative Mempools
 


### PR DESCRIPTION
seems that allowing keccak(X||OWN) opens an attack surface (shared storage between accounts)
rule 3 alone is enough to access balances and allowances of 2 entitys (paymaster and account) - which is OK.
added also slot+offset