### PR TITLE
Add tests for high gas usage transactions

### DIFF
--- a/test/entrypoint.test.ts
+++ b/test/entrypoint.test.ts
@@ -433,6 +433,70 @@ describe('EntryPoint', function () {
         await calcGasUsage(rcpt, entryPoint, beneficiaryAddress)
       })
 
+      it.only('account should pay for high gas usage tx', async function () {
+        const iterations = 800
+        const count = await counter.populateTransaction.gasWaster(iterations, "")
+        console.log(count)
+        const accountExec = await account.populateTransaction.execute(counter.address, 0, count.data!)
+        const op = await fillAndSign({
+          sender: account.address,
+          callData: accountExec.data,
+          verificationGasLimit: 1e6,
+          callGasLimit: 188e5
+        }, accountOwner, entryPoint)
+        const beneficiaryAddress = createAddress()
+        console.log('  == offset before', await counter.offset())
+        console.log('  == state before', await counter.xxx(iterations))
+        // for estimateGas, must specify maxFeePerGas, otherwise our gas check fails
+        console.log('  == est gas=', await entryPoint.estimateGas.handleOps([op], beneficiaryAddress, { maxFeePerGas: 1e9 }).then(tostr))
+
+        // must specify at least on of maxFeePerGas, gasLimit
+        // (gasLimit, to prevent estimateGas to fail on missing maxFeePerGas, see above..)
+        const rcpt = await entryPoint.handleOps([op], beneficiaryAddress, {
+          maxFeePerGas: 1e9,
+          gasLimit: 188e5
+        }).then(async t => await t.wait())
+
+        console.log('rcpt.gasUsed=', rcpt.gasUsed.toString(), rcpt.transactionHash)
+        console.log('  == offset after', await counter.offset())
+        console.log('  == state after', await counter.xxx(iterations))
+        expect(await counter.offset()).to.equal(iterations)
+
+        await calcGasUsage(rcpt, entryPoint, beneficiaryAddress)
+      })
+
+      it.only('account should pay for high gas usage tx', async function () {
+        const iterations = 800
+        const count = await counter.populateTransaction.gasWaster(iterations, "")
+        console.log(count)
+        const accountExec = await account.populateTransaction.execute(counter.address, 0, count.data!)
+        const op = await fillAndSign({
+          sender: account.address,
+          callData: accountExec.data,
+          verificationGasLimit: 1e6,
+          callGasLimit: 188e5
+        }, accountOwner, entryPoint)
+        const beneficiaryAddress = createAddress()
+        console.log('  == offset before', await counter.offset())
+        console.log('  == state before', await counter.xxx(iterations))
+        // for estimateGas, must specify maxFeePerGas, otherwise our gas check fails
+        console.log('  == est gas=', await entryPoint.estimateGas.handleOps([op], beneficiaryAddress, { maxFeePerGas: 1e9 }).then(tostr))
+
+        // must specify at least on of maxFeePerGas, gasLimit
+        // (gasLimit, to prevent estimateGas to fail on missing maxFeePerGas, see above..)
+        const rcpt = await entryPoint.handleOps([op], beneficiaryAddress, {
+          maxFeePerGas: 1e9,
+          gasLimit: 288e5
+        }).then(async t => await t.wait())
+
+        console.log('rcpt.gasUsed=', rcpt.gasUsed.toString(), rcpt.transactionHash)
+        console.log('  == offset after', await counter.offset())
+        console.log('  == state after', await counter.xxx(iterations))
+        expect(await counter.offset()).to.equal(iterations)
+
+        await calcGasUsage(rcpt, entryPoint, beneficiaryAddress)
+      })
+
       it('legacy mode (maxPriorityFee==maxFeePerGas) should not use "basefee" opcode', async function () {
         const op = await fillAndSign({
           sender: account.address,

--- a/test/entrypoint.test.ts
+++ b/test/entrypoint.test.ts
@@ -433,15 +433,15 @@ describe('EntryPoint', function () {
         await calcGasUsage(rcpt, entryPoint, beneficiaryAddress)
       })
 
-      it.only('account should pay for high gas usage tx', async function () {
-        const iterations = 120
+      it('account should pay for high gas usage tx', async function () {
+        const iterations = 45
         const count = await counter.populateTransaction.gasWaster(iterations, "")
         const accountExec = await account.populateTransaction.execute(counter.address, 0, count.data!)
         const op = await fillAndSign({
           sender: account.address,
           callData: accountExec.data,
           verificationGasLimit: 1e6,
-          callGasLimit: 29e5
+          callGasLimit: 11e5
         }, accountOwner, entryPoint)
         const beneficiaryAddress = createAddress()
         const offsetBefore = await counter.offset()
@@ -453,26 +453,30 @@ describe('EntryPoint', function () {
         // (gasLimit, to prevent estimateGas to fail on missing maxFeePerGas, see above..)
         const rcpt = await entryPoint.handleOps([op], beneficiaryAddress, {
           maxFeePerGas: 1e9,
-          gasLimit: 188e5
+          gasLimit: 13e5
         }).then(async t => await t.wait())
 
         console.log('rcpt.gasUsed=', rcpt.gasUsed.toString(), rcpt.transactionHash)
         await calcGasUsage(rcpt, entryPoint, beneficiaryAddress)
 
+        // check that the state of the counter contract is updated
+        // this ensures that the `callGasLimit` is high enough
+        // therefore this value can be used as a reference in the test below
         console.log('  == offset after', await counter.offset())
         expect(await counter.offset()).to.equal(offsetBefore.add(iterations))
       })
 
-      it.only('account should not pay if the executor sets a too low gas limit', async function () {
-        const iterations = 120
+      it('account should not pay if too low gas limit was set', async function () {
+        const iterations = 45
         const count = await counter.populateTransaction.gasWaster(iterations, "")
         const accountExec = await account.populateTransaction.execute(counter.address, 0, count.data!)
         const op = await fillAndSign({
           sender: account.address,
           callData: accountExec.data,
           verificationGasLimit: 1e6,
-          callGasLimit: 29e5
+          callGasLimit: 11e5
         }, accountOwner, entryPoint)
+        const inititalAccountBalance = await getBalance(account.address)
         const beneficiaryAddress = createAddress()
         const offsetBefore = await counter.offset()
         console.log('  == offset before', offsetBefore)
@@ -481,16 +485,14 @@ describe('EntryPoint', function () {
 
         // must specify at least on of maxFeePerGas, gasLimit
         // (gasLimit, to prevent estimateGas to fail on missing maxFeePerGas, see above..)
-        const rcpt = await entryPoint.handleOps([op], beneficiaryAddress, {
+        // this transaction should revert as the gasLimit is too low to satisfy the expected `callGasLimit` (see test above)
+        await expect(entryPoint.handleOps([op], beneficiaryAddress, {
           maxFeePerGas: 1e9,
-          gasLimit: 29e5
-        }).then(async t => await t.wait())
+          gasLimit: 12e5
+        })).to.revertedWith('Transaction ran out of gas')
 
-        console.log('rcpt.gasUsed=', rcpt.gasUsed.toString(), rcpt.transactionHash)
-        await calcGasUsage(rcpt, entryPoint, beneficiaryAddress)
-
-        console.log('  == offset after', await counter.offset())
-        expect(await counter.offset()).to.equal(offsetBefore.add(iterations))
+        // Make sure that the user did not pay for the transaction
+        expect(await getBalance(account.address)).to.eq(inititalAccountBalance)
       })
 
       it('legacy mode (maxPriorityFee==maxFeePerGas) should not use "basefee" opcode', async function () {

--- a/test/entrypoint.test.ts
+++ b/test/entrypoint.test.ts
@@ -440,7 +440,7 @@ describe('EntryPoint', function () {
         const op = await fillAndSign({
           sender: account.address,
           callData: accountExec.data,
-          verificationGasLimit: 1e6,
+          verificationGasLimit: 1e5,
           callGasLimit: 11e5
         }, accountOwner, entryPoint)
         const beneficiaryAddress = createAddress()
@@ -473,7 +473,7 @@ describe('EntryPoint', function () {
         const op = await fillAndSign({
           sender: account.address,
           callData: accountExec.data,
-          verificationGasLimit: 1e6,
+          verificationGasLimit: 1e5,
           callGasLimit: 11e5
         }, accountOwner, entryPoint)
         const inititalAccountBalance = await getBalance(account.address)

--- a/test/entrypoint.test.ts
+++ b/test/entrypoint.test.ts
@@ -435,7 +435,7 @@ describe('EntryPoint', function () {
 
       it('account should pay for high gas usage tx', async function () {
         const iterations = 45
-        const count = await counter.populateTransaction.gasWaster(iterations, "")
+        const count = await counter.populateTransaction.gasWaster(iterations, '')
         const accountExec = await account.populateTransaction.execute(counter.address, 0, count.data!)
         const op = await fillAndSign({
           sender: account.address,
@@ -468,7 +468,7 @@ describe('EntryPoint', function () {
 
       it('account should not pay if too low gas limit was set', async function () {
         const iterations = 45
-        const count = await counter.populateTransaction.gasWaster(iterations, "")
+        const count = await counter.populateTransaction.gasWaster(iterations, '')
         const accountExec = await account.populateTransaction.execute(counter.address, 0, count.data!)
         const op = await fillAndSign({
           sender: account.address,

--- a/test/testutils.ts
+++ b/test/testutils.ts
@@ -87,7 +87,7 @@ export async function calcGasUsage (rcpt: ContractReceipt, entryPoint: EntryPoin
   const tx = await ethers.provider.getTransaction(rcpt.transactionHash)
   console.log('\t== gasDiff', actualGas.toNumber() - actualGasUsed.toNumber() - callDataCost(tx.data))
   if (beneficiaryAddress != null) {
-    expect(await getBalance(beneficiaryAddress)).to.eq(actualGasCost.toNumber())
+    expect(await ethers.provider.getBalance(beneficiaryAddress)).to.eq(actualGasCost)
   }
   return { actualGasCost }
 }

--- a/test/testutils.ts
+++ b/test/testutils.ts
@@ -87,7 +87,7 @@ export async function calcGasUsage (rcpt: ContractReceipt, entryPoint: EntryPoin
   const tx = await ethers.provider.getTransaction(rcpt.transactionHash)
   console.log('\t== gasDiff', actualGas.toNumber() - actualGasUsed.toNumber() - callDataCost(tx.data))
   if (beneficiaryAddress != null) {
-    expect(await ethers.provider.getBalance(beneficiaryAddress)).to.eq(actualGasCost)
+    expect(await getBalance(beneficiaryAddress)).to.eq(actualGasCost.toNumber())
   }
   return { actualGasCost }
 }


### PR DESCRIPTION
The added tests should show the scenario where a user operation with a high `callGasLimit` is submitted. In this case it is important that the `gasLimit` is correctly set, else it is possible to use the 1/64th rule of [EIP-150](https://eips.ethereum.org/EIPS/eip-150) to make the user operation fail and the account pays for it.

If this is possible it could be used as an attack vector. The attacker would submit a bundle with the high gas usage tx with a too low gas value. Even when the user estimated everything correctly the transaction would fail because not enough gas is available. The costs for the execution would still be deducted from the account. Therefore the submitter could perform a denial of service attack for which the account that is being attacked would pay. 

The first tests below shows that high gas transaction can be executed and refunded. The second test checks that the transaction is reverted in case the gas limit is set too low, to avoid the attack described above.