### PR TITLE
Clarify that verifying the userOpHash is not a requirement

### DIFF
--- a/eip/EIPS/eip-4337.md
+++ b/eip/EIPS/eip-4337.md
@@ -121,16 +121,15 @@ interface IAccount {
 }
 ```
 
-The account
+The `userOpHash` is a hash over the userOp (except signature), entryPoint and chainId.  The account:
 
 * MUST validate the caller is a trusted EntryPoint
-* The userOpHash is a hash over the userOp (except signature), entryPoint and chainId
 * If the account does not support signature aggregation, it MUST validate the signature is a valid signature of the `userOpHash`, and
   SHOULD return SIG_VALIDATION_FAILED (and not revert) on signature mismatch. Any other error should revert.
 * MUST pay the entryPoint (caller) at least the "missingAccountFunds" (which might be zero, in case current account's deposit is high enough)
 * The account MAY pay more than this minimum, to cover future transactions (it can always issue `withdrawTo` to retrieve it)
 * The `aggregator` SHOULD be ignored for accounts that don't use an aggregator
-* The return value is packed of sigFailure, validUntil and validAfter  timestamps.
+* The return value MUST be packed of `sigFailure`, `validUntil` and `validAfter` timestamps.
   * `sigFailure` is 1 byte value of "1" the signature check failed (should not revert on signature failure, to support estimate)
   * `validUntil` is 8-byte timestamp value, or zero for "infinite". The UserOp is valid only up to this time.
   * `validAfter` is 8-byte timestamp. The UserOp is valid only after this time.


### PR DESCRIPTION
The way it's worded right now, it sounds like the account needs to verify the `userOpHash`, when in fact it doesn't have to, since the entryPoint is trusted.  Just re-organizing the text to make it clearer.