### PR TITLE
Specify that the client should check for sigFailed

### DIFF
--- a/eip/EIPS/eip-4337.md
+++ b/eip/EIPS/eip-4337.md
@@ -305,7 +305,7 @@ Either `validateUserOp` or `validatePaymasterUserOp` may return a "validAfter" a
 The simulateValidation call returns this range.
 A node MAY drop a UserOperation if it expires too soon (e.g. wouldn't make it to the next block)
 
-If the `ValidationResult` includes `sigFail`, the client MUST drop the `UserOperation`.
+If the `ValidationResult` includes `sigFail`, the client SHOULD drop the `UserOperation`.
 
 The operations differ in their opcode banning policy.
 In order to distinguish between them, there is a call to the NUMBER opcode (`block.number`), used as a delimiter between the 3 functions.
@@ -532,7 +532,7 @@ The result `SHOULD` be set to the **userOpHash** if and only if the request pass
     * The `data` field SHOULD contain a `minimumStake` and `minimumUnstakeDelay`
   * **code: -32506** - transaction rejected because wallet specified unsupported signature aggregator
     * The `data` field SHOULD contain an `aggregator` value
-  * **code: -32507** - transaction rejected because either the UserOperation signature or the paymaster signature is invalid
+  * **code: -32507** - transaction rejected because of wallet signature check failed (or paymaster signature, if the paymaster uses its data as signature)
 
 ##### Example:
 

--- a/eip/EIPS/eip-4337.md
+++ b/eip/EIPS/eip-4337.md
@@ -305,6 +305,8 @@ Either `validateUserOp` or `validatePaymasterUserOp` may return a "validAfter" a
 The simulateValidation call returns this range.
 A node MAY drop a UserOperation if it expires too soon (e.g. wouldn't make it to the next block)
 
+If the `ValidationResult` includes `sigFail`, the client MUST drop the `UserOperation`.
+
 The operations differ in their opcode banning policy.
 In order to distinguish between them, there is a call to the NUMBER opcode (`block.number`), used as a delimiter between the 3 functions.
 While simulating `userOp` validation, the client should make sure that:
@@ -530,6 +532,7 @@ The result `SHOULD` be set to the **userOpHash** if and only if the request pass
     * The `data` field SHOULD contain a `minimumStake` and `minimumUnstakeDelay`
   * **code: -32506** - transaction rejected because wallet specified unsupported signature aggregator
     * The `data` field SHOULD contain an `aggregator` value
+  * **code: -32507** - transaction rejected because either the UserOperation signature or the paymaster signature is invalid
 
 ##### Example:
 


### PR DESCRIPTION
`sigFailed` is returned as part of the `ValidationResult` from `simulateValidation`, but the spec does not ask the clients to consider it.

Related: https://github.com/eth-infinitism/bundler/pull/39