### PR TITLE
Use the correct GnosisSafeProxy creation code

### DIFF
--- a/contracts/gnosis/GnosisAccountFactory.sol
+++ b/contracts/gnosis/GnosisAccountFactory.sol
@@ -55,7 +55,7 @@ contract GnosisSafeAccountFactory {
         bytes memory initializer = getInitializer(owner);
         //copied from deployProxyWithNonce
         bytes32 salt2 = keccak256(abi.encodePacked(keccak256(initializer), salt));
-        bytes memory deploymentData = abi.encodePacked(type(GnosisSafeProxy).creationCode, uint256(uint160(safeSingleton)));
+        bytes memory deploymentData = abi.encodePacked(proxyFactory.proxyCreationCode(), uint256(uint160(safeSingleton)));
         return Create2.computeAddress(bytes32(salt2), keccak256(deploymentData), address (proxyFactory));
     }
 }


### PR DESCRIPTION
Reading creation code from the type "GnosisSafeProxy" opens up the risk that the creation code from the imported library is different than the one actually deployed on-chain.  This would result in the counterfactual address being different from the deployed address (which happened to me).

Fortunately, we can read the creation code from the proxy factory itself: https://github.com/safe-global/safe-contracts/blob/767ef36bba88bdbc0c9fe3708a4290cabef4c376/contracts/proxies/GnosisSafeProxyFactory.sol#L33