### PR TITLE
fix: update invalid nonce method signature in test utils

### DIFF
--- a/test/UserOp.ts
+++ b/test/UserOp.ts
@@ -198,7 +198,7 @@ export async function fillUserOp (op: Partial<UserOperation>, entryPoint?: Entry
   }
   if (op1.nonce == null) {
     if (provider == null) throw new Error('must have entryPoint to autofill nonce')
-    const c = new Contract(op.sender!, ['function nonce() view returns(address)'], provider)
+    const c = new Contract(op.sender!, ['function nonce() view returns(uint256)'], provider)
     op1.nonce = await c.nonce().catch(rethrow())
   }
   if (op1.callGasLimit == null && op.callData != null) {


### PR DESCRIPTION
## Summary

The return type of the `nonce` method is updated from `address` to `uint256` in the `fillUserOp` test util