### PR TITLE
add nonReentrant in simulateHandleOp

### DIFF
--- a/contracts/core/EntryPoint.sol
+++ b/contracts/core/EntryPoint.sol
@@ -181,7 +181,7 @@ contract EntryPoint is IEntryPoint, StakeManager, NonceManager, ReentrancyGuard 
     }
 
     /// @inheritdoc IEntryPoint
-    function simulateHandleOp(UserOperation calldata op, address target, bytes calldata targetCallData) external override {
+    function simulateHandleOp(UserOperation calldata op, address target, bytes calldata targetCallData) external override nonReentrant {
 
         UserOpInfo memory opInfo;
         _simulationOnlyValidations(op);


### PR DESCRIPTION
Add nonReentrant in simulateHandleOp to keep simulation and execution consistent.