### PR TITLE
refactor: check for token support before `transferFrom`

### DIFF
--- a/contracts/samples/DepositPaymaster.sol
+++ b/contracts/samples/DepositPaymaster.sol
@@ -60,9 +60,9 @@ contract DepositPaymaster is BasePaymaster {
      * @param amount the amount of token to deposit.
      */
     function addDepositFor(IERC20 token, address account, uint256 amount) external {
+        require(oracles[token] != NULL_ORACLE, "unsupported token");
         //(sender must have approval for the paymaster)
         token.safeTransferFrom(msg.sender, address(this), amount);
-        require(oracles[token] != NULL_ORACLE, "unsupported token");
         balances[token][account] += amount;
         if (msg.sender == account) {
             lockTokenDeposit();


### PR DESCRIPTION
It would be better to check for token support before you even transfer the tokens, this will save gas.