### PR TITLE
fix: deterministicDeployment for replay protection chain

### DIFF
--- a/deploy/1_deploy_entrypoint.ts
+++ b/deploy/1_deploy_entrypoint.ts
@@ -1,16 +1,13 @@
 import { HardhatRuntimeEnvironment } from 'hardhat/types'
 import { DeployFunction } from 'hardhat-deploy/types'
-import { Create2Factory } from '../src/Create2Factory'
-import { ethers } from 'hardhat'
 
 const deployEntryPoint: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
-  const provider = ethers.provider
-  const from = await provider.getSigner().getAddress()
-  await new Create2Factory(ethers.provider).deployFactory()
+  const { deployments, getNamedAccounts } = hre
+  const { deployer } = await getNamedAccounts()
 
-  const ret = await hre.deployments.deploy(
+  const ret = await deployments.deploy(
     'EntryPoint', {
-      from,
+      from: deployer,
       args: [],
       gasLimit: 6e6,
       deterministicDeployment: true

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
   "author": "",
   "license": "ISC",
   "devDependencies": {
+    "@gnosis.pm/safe-singleton-factory": "^1.0.14",
     "@nomiclabs/hardhat-ethers": "^2.0.2",
     "@nomiclabs/hardhat-waffle": "^2.0.1",
     "@typechain/ethers-v5": "^10.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -476,6 +476,11 @@
   resolved "https://registry.yarnpkg.com/@gnosis.pm/safe-contracts/-/safe-contracts-1.3.0.tgz#316741a7690d8751a1f701538cfc9ec80866eedc"
   integrity sha512-1p+1HwGvxGUVzVkFjNzglwHrLNA67U/axP0Ct85FzzH8yhGJb4t9jDjPYocVMzLorDoWAfKicGy1akPY9jXRVw==
 
+"@gnosis.pm/safe-singleton-factory@^1.0.14":
+  version "1.0.14"
+  resolved "https://registry.yarnpkg.com/@gnosis.pm/safe-singleton-factory/-/safe-singleton-factory-1.0.14.tgz#42dae9a91fda21b605f94bfe310a7fccc6a4d738"
+  integrity sha512-xZ26c9uKzpd5Sm8ux0sZHt5QC8n+Q2z1/X5xjPnd8aT5EcKH5t1GgLbAqjrMFmXVIOkiWSc7wi2Bj4XfgtiyaQ==
+
 "@humanwhocodes/config-array@^0.11.8":
   version "0.11.8"
   resolved "https://registry.yarnpkg.com/@humanwhocodes/config-array/-/config-array-0.11.8.tgz#03595ac2075a4dc0f191cc2131de14fbd7d410b9"


### PR DESCRIPTION
**Current Behavior**: fail to deploy on replay protection chains, cause by legacy pre-EIP155 not supported

**PR**: use [Singleton factory](https://github.com/safe-global/safe-singleton-factory) from Safe to enable such deployment on replay protection chains, by include `chainId` into signed transactions