### PR TITLE
Add yarn.lock consistency check to GitHub Actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,6 +12,21 @@ env:
 
 # todo: extract shared seto/checkout/install/compile, instead of repeat in each job.
 jobs:
+  check-yarn-lock:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v2
+      - name: Use Node.js
+        uses: actions/setup-node@v2
+        with:
+          node-version: 14
+      - name: Install dependencies with frozen lockfile
+        run: yarn install --frozen-lockfile
+      - name: Check for changes in yarn.lock
+        run: |
+          git diff --exit-code yarn.lock || (echo "yarn.lock must be updated to match package.json changes." && exit 1)
 
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This PR adds a new job to our GitHub Actions which verifies the consistency of `yarn.lock` with `package.json`. 

The job works by running `yarn install --frozen-lockfile` and checking for modifications to `yarn.lock`. If changes are detected, the `yarn.lock` file isn't in sync with `package.json`, flagging an inconsistency. 

Incorporating this check into our continuous integration process ensures accurate dependencies across different environments and helps to prevent build failures. It will run as the first job in our workflow, prompting contributors to update their `yarn.lock` file when necessary.