### PR TITLE
[Fix] Add "etherscan" to HardhatUserConfig to resolve Type Error

### DIFF
--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -61,9 +61,11 @@ const config: HardhatUserConfig = {
   mocha: {
     timeout: 10000
   },
-    etherscan: {
+
+  etherscan: {
       apiKey: process.env.ETHERSCAN_API_KEY
   }
+  
 }
 
 // coverage chokes on the "compilers" settings

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -5,7 +5,6 @@ import '@typechain/hardhat'
 import { HardhatUserConfig } from 'hardhat/config'
 import 'hardhat-deploy'
 
-
 import 'solidity-coverage'
 
 import * as fs from 'fs'

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -61,11 +61,8 @@ const config: HardhatUserConfig = {
   mocha: {
     timeout: 10000
   },
-
-  verify: {
     etherscan: {
       apiKey: process.env.ETHERSCAN_API_KEY
-    }
   }
 }
 

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -1,9 +1,10 @@
 
-import 'hardhat-deploy'
+import '@nomiclabs/hardhat-etherscan'
 import '@nomiclabs/hardhat-waffle'
 import '@typechain/hardhat'
 import { HardhatUserConfig } from 'hardhat/config'
-import '@nomiclabs/hardhat-etherscan'
+import 'hardhat-deploy'
+
 
 import 'solidity-coverage'
 
@@ -61,10 +62,11 @@ const config: HardhatUserConfig = {
     timeout: 10000
   },
 
-  etherscan: {
-    apiKey: process.env.ETHERSCAN_API_KEY
+  verify: {
+    etherscan: {
+      apiKey: process.env.ETHERSCAN_API_KEY
+    }
   }
-
 }
 
 // coverage chokes on the "compilers" settings

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -1,7 +1,8 @@
+
+import 'hardhat-deploy'
 import '@nomiclabs/hardhat-waffle'
 import '@typechain/hardhat'
 import { HardhatUserConfig } from 'hardhat/config'
-import 'hardhat-deploy'
 import '@nomiclabs/hardhat-etherscan'
 
 import 'solidity-coverage'

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -1,4 +1,3 @@
-
 import '@nomiclabs/hardhat-etherscan'
 import '@nomiclabs/hardhat-waffle'
 import '@typechain/hardhat'

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -63,9 +63,9 @@ const config: HardhatUserConfig = {
   },
 
   etherscan: {
-      apiKey: process.env.ETHERSCAN_API_KEY
+    apiKey: process.env.ETHERSCAN_API_KEY
   }
-  
+
 }
 
 // coverage chokes on the "compilers" settings


### PR DESCRIPTION
In this PR, we address an error encountered while running `yarn tsc` due to the incorrect ordering of import statements.

### The Issue:
Running `yarn tsc` yielded a Type error related to the `etherscan` property in `HardhatUserConfig`, as it wasn't recognized.

```typescript
hardhat.config.ts:70:3 - error TS2322: Type '{
   ...
  etherscan: {
    apiKey: process.env.ETHERSCAN_API_KEY
  };
}' is not assignable to type 'HardhatUserConfig'.
  Object literal may only specify known properties,
   and 'etherscan' does not exist in type 'HardhatUserConfig'.
  ```

### The Fix:

The root cause was traced back to the order of import statements, which affected the application of type extensions. 

By reordering ['@nomiclabs/hardhat-etherscan'](https://www.npmjs.com/package/@nomiclabs/hardhat-etherscan) import to the top of the file we can be sure that the `etherscan` property will exist on the `HardhatUserConfig`.

This enables the successful execution of `yarn tsc` without the previously encountered error. 

### Error Deep Dive:

Below we can see that `'hardhat-deploy'` package (which was imported before `@nomiclabs/hardhat-etherscan`) is copying the `userConfig.etherscan` to `userConfig.verify.etherscan`. 

This means, at the bare minimum, the `@nomiclabs/hardhat-etherscan` should be imported before it.

[Github Full Code:](https://github.com/wighawag/hardhat-deploy/blob/v0.11.23/src/index.ts#L162-L164)

```typescript
extendConfig(
  (config: HardhatConfig, userConfig: Readonly<HardhatUserConfig>) => {
    ...
    // backward compatibility for runtime (js)
    // eslint-disable-next-line @typescript-eslint/no-explicit-any
    if ((userConfig as any).etherscan) {
      // eslint-disable-next-line @typescript-eslint/no-explicit-any
      config.verify.etherscan = (userConfig as any).etherscan;
    }
  }
);