### PR TITLE
Refactor _payPrefund with Yul

### DIFF
--- a/contracts/core/BaseAccount.sol
+++ b/contracts/core/BaseAccount.sol
@@ -18,7 +18,7 @@ abstract contract BaseAccount is IAccount {
 
     //return value in case of signature failure, with no time-range.
     // equivalent to _packValidationData(true,0,0);
-    uint256 internal constant SIG_VALIDATION_FAILED = 1;
+    uint256 constant internal SIG_VALIDATION_FAILED = 1;
 
     /**
      * Return the account nonce.
@@ -40,11 +40,7 @@ abstract contract BaseAccount is IAccount {
      * subclass doesn't need to override this method. Instead, it should override the specific internal validation methods.
      */
     function validateUserOp(UserOperation calldata userOp, bytes32 userOpHash, uint256 missingAccountFunds)
-        external
-        virtual
-        override
-        returns (uint256 validationData)
-    {
+    external override virtual returns (uint256 validationData) {
         _requireFromEntryPoint();
         validationData = _validateSignature(userOp, userOpHash);
         _validateNonce(userOp.nonce);
@@ -54,7 +50,7 @@ abstract contract BaseAccount is IAccount {
     /**
      * ensure the request comes from the known entrypoint.
      */
-    function _requireFromEntryPoint() internal view virtual {
+    function _requireFromEntryPoint() internal virtual view {
         require(msg.sender == address(entryPoint()), "account: not from EntryPoint");
     }
 
@@ -72,9 +68,7 @@ abstract contract BaseAccount is IAccount {
      *      Note that the validation code cannot use block.timestamp (or block.number) directly.
      */
     function _validateSignature(UserOperation calldata userOp, bytes32 userOpHash)
-        internal
-        virtual
-        returns (uint256 validationData);
+    internal virtual returns (uint256 validationData);
 
     /**
      * Validate the nonce of the UserOperation.
@@ -92,7 +86,8 @@ abstract contract BaseAccount is IAccount {
      *
      * solhint-disable-next-line no-empty-blocks
      */
-    function _validateNonce(uint256 nonce) internal view virtual {}
+    function _validateNonce(uint256 nonce) internal view virtual {
+    }
 
     /**
      * sends to the entrypoint (msg.sender) the missing funds for this transaction.

--- a/contracts/core/BaseAccount.sol
+++ b/contracts/core/BaseAccount.sol
@@ -18,7 +18,7 @@ abstract contract BaseAccount is IAccount {
 
     //return value in case of signature failure, with no time-range.
     // equivalent to _packValidationData(true,0,0);
-    uint256 constant internal SIG_VALIDATION_FAILED = 1;
+    uint256 internal constant SIG_VALIDATION_FAILED = 1;
 
     /**
      * Return the account nonce.
@@ -40,7 +40,11 @@ abstract contract BaseAccount is IAccount {
      * subclass doesn't need to override this method. Instead, it should override the specific internal validation methods.
      */
     function validateUserOp(UserOperation calldata userOp, bytes32 userOpHash, uint256 missingAccountFunds)
-    external override virtual returns (uint256 validationData) {
+        external
+        virtual
+        override
+        returns (uint256 validationData)
+    {
         _requireFromEntryPoint();
         validationData = _validateSignature(userOp, userOpHash);
         _validateNonce(userOp.nonce);
@@ -50,7 +54,7 @@ abstract contract BaseAccount is IAccount {
     /**
      * ensure the request comes from the known entrypoint.
      */
-    function _requireFromEntryPoint() internal virtual view {
+    function _requireFromEntryPoint() internal view virtual {
         require(msg.sender == address(entryPoint()), "account: not from EntryPoint");
     }
 
@@ -68,7 +72,9 @@ abstract contract BaseAccount is IAccount {
      *      Note that the validation code cannot use block.timestamp (or block.number) directly.
      */
     function _validateSignature(UserOperation calldata userOp, bytes32 userOpHash)
-    internal virtual returns (uint256 validationData);
+        internal
+        virtual
+        returns (uint256 validationData);
 
     /**
      * Validate the nonce of the UserOperation.
@@ -86,8 +92,7 @@ abstract contract BaseAccount is IAccount {
      *
      * solhint-disable-next-line no-empty-blocks
      */
-    function _validateNonce(uint256 nonce) internal view virtual {
-    }
+    function _validateNonce(uint256 nonce) internal view virtual {}
 
     /**
      * sends to the entrypoint (msg.sender) the missing funds for this transaction.
@@ -99,8 +104,9 @@ abstract contract BaseAccount is IAccount {
      */
     function _payPrefund(uint256 missingAccountFunds) internal virtual {
         if (missingAccountFunds != 0) {
-            (bool success,) = payable(msg.sender).call{value : missingAccountFunds, gas : type(uint256).max}("");
-            (success);
+            assembly {
+                pop(call(sub(0x00, 0x01), caller(), missingAccountFunds, 0, 0, 0, 0))
+            }
             //ignore failure (its EntryPoint's job to verify, not account.)
         }
     }


### PR DESCRIPTION
This modification save some gas and is equivalent to the function made with Solidity.

Test made with forge

```solidity
// SPDX-License-Identifier: UNLICENSED
pragma solidity ^0.8.13;

import "forge-std/Test.sol";

contract PayPrefund {
    function payPrefundOriginal(uint256 missingAccountFunds) external {
        if (missingAccountFunds != 0) {
            (bool success,) = payable(msg.sender).call{value: missingAccountFunds, gas: type(uint256).max}("");
            (success);
            //ignore failure (its EntryPoint's job to verify, not account.)
        }
    }

    function payPrefundYul(uint256 missingAccountFunds) external {
        if (missingAccountFunds != 0) {
            assembly {
                pop(call(sub(0x00, 0x01), caller(), missingAccountFunds, 0, 0, 0, 0))
            }
            //ignore failure (its EntryPoint's job to verify, not account.)
        }
    }
}

contract PayPrefundTest is Test {
    PayPrefund public payPrefund;
    address public caller = makeAddr("caller");

    function setUp() public {
        payPrefund = new PayPrefund();
        vm.deal(address(payPrefund), 500);
        vm.startPrank(caller);
    }

    function testOriginal() public {
        payPrefund.payPrefundOriginal(100);
    }

    function testYul() public {
        payPrefund.payPrefundYul(100);
    }
}
```

![image](https://github.com/eth-infinitism/account-abstraction/assets/46317127/c790e3e1-496c-4f40-97e0-a7a774ec57f9)
