### PR TITLE
Rename getAddress -> getAccountAddress

### DIFF
--- a/contracts/samples/SimpleAccountFactory.sol
+++ b/contracts/samples/SimpleAccountFactory.sol
@@ -26,7 +26,7 @@ contract SimpleAccountFactory {
      * This method returns an existing account address so that entryPoint.getSenderAddress() would work even after account creation
      */
     function createAccount(address owner,uint256 salt) public returns (SimpleAccount ret) {
-        address addr = getAddress(owner, salt);
+        address addr = getAccountAddress(owner, salt);
         uint codeSize = addr.code.length;
         if (codeSize > 0) {
             return SimpleAccount(payable(addr));
@@ -40,7 +40,7 @@ contract SimpleAccountFactory {
     /**
      * calculate the counterfactual address of this account as it would be returned by createAccount()
      */
-    function getAddress(address owner,uint256 salt) public view returns (address) {
+    function getAccountAddress(address owner,uint256 salt) public view returns (address) {
         return Create2.computeAddress(bytes32(salt), keccak256(abi.encodePacked(
                 type(ERC1967Proxy).creationCode,
                 abi.encode(

--- a/contracts/samples/gnosis/GnosisAccountFactory.sol
+++ b/contracts/samples/gnosis/GnosisAccountFactory.sol
@@ -21,7 +21,7 @@ contract GnosisSafeAccountFactory {
     }
 
     function createAccount(address owner,uint256 salt) public returns (address) {
-        address addr = getAddress(owner, salt);
+        address addr = getAccountAddress(owner, salt);
         uint codeSize = addr.code.length;
         if (codeSize > 0) {
             return addr;
@@ -51,7 +51,7 @@ contract GnosisSafeAccountFactory {
      * calculate the counterfactual address of this account as it would be returned by createAccount()
      * (uses the same "create2 signature" used by GnosisSafeProxyFactory.createProxyWithNonce)
      */
-    function getAddress(address owner,uint256 salt) public view returns (address) {
+    function getAccountAddress(address owner,uint256 salt) public view returns (address) {
         bytes memory initializer = getInitializer(owner);
         //copied from deployProxyWithNonce
         bytes32 salt2 = keccak256(abi.encodePacked(keccak256(initializer), salt));

--- a/contracts/test/BrokenBlsAccount.sol
+++ b/contracts/test/BrokenBlsAccount.sol
@@ -60,7 +60,7 @@ contract BrokenBLSAccountFactory {
      */
     function createAccount(uint salt, uint256[4] memory aPublicKey) public returns (BrokenBLSAccount) {
 
-        address addr = getAddress(salt, aPublicKey);
+        address addr = getAccountAddress(salt, aPublicKey);
         uint codeSize = addr.code.length;
         if (codeSize > 0) {
             return BrokenBLSAccount(payable(addr));
@@ -74,7 +74,7 @@ contract BrokenBLSAccountFactory {
     /**
      * calculate the counterfactual address of this account as it would be returned by createAccount()
      */
-    function getAddress(uint salt, uint256[4] memory aPublicKey) public view returns (address) {
+    function getAccountAddress(uint salt, uint256[4] memory aPublicKey) public view returns (address) {
         return Create2.computeAddress(bytes32(salt), keccak256(abi.encodePacked(
                 type(ERC1967Proxy).creationCode,
                 abi.encode(

--- a/contracts/test/TestAggregatedAccountFactory.sol
+++ b/contracts/test/TestAggregatedAccountFactory.sol
@@ -25,7 +25,7 @@ contract TestAggregatedAccountFactory {
      * This method returns an existing account address so that entryPoint.getSenderAddress() would work even after account creation
      */
     function createAccount(address owner,uint256 salt) public returns (TestAggregatedAccount ret) {
-        address addr = getAddress(owner, salt);
+        address addr = getAccountAddress(owner, salt);
         uint codeSize = addr.code.length;
         if (codeSize > 0) {
             return TestAggregatedAccount(payable(addr));
@@ -39,7 +39,7 @@ contract TestAggregatedAccountFactory {
     /**
      * calculate the counterfactual address of this account as it would be returned by createAccount()
      */
-    function getAddress(address owner,uint256 salt) public view returns (address) {
+    function getAccountAddress(address owner,uint256 salt) public view returns (address) {
         return Create2.computeAddress(bytes32(salt), keccak256(abi.encodePacked(
                 type(ERC1967Proxy).creationCode,
                 abi.encode(

--- a/gascalc/GasChecker.ts
+++ b/gascalc/GasChecker.ts
@@ -135,7 +135,7 @@ export class GasChecker {
       const salt = n
       // const initCode = this.accountInitCode(fact, salt)
 
-      const addr = await fact.getAddress(this.accountOwner.address, salt)
+      const addr = await fact.getAccountAddress(this.accountOwner.address, salt)
 
       if (!this.createdAccounts.has(addr)) {
         // explicit call to fillUseROp with no "entryPoint", to make sure we manually fill everything and

--- a/test/gnosis.test.ts
+++ b/test/gnosis.test.ts
@@ -173,7 +173,7 @@ describe('Gnosis Proxy', function () {
       accountFactory.interface.encodeFunctionData('createAccount', [ownerAddress, 123])
     ])
 
-    counterfactualAddress = await accountFactory.callStatic.getAddress(ownerAddress, 123)
+    counterfactualAddress = await accountFactory.callStatic.getAccountAddress(ownerAddress, 123)
     expect(!await isDeployed(counterfactualAddress))
 
     await ethersSigner.sendTransaction({

--- a/test/testutils.ts
+++ b/test/testutils.ts
@@ -111,7 +111,7 @@ export async function getAggregatedAccountInitCode (entryPoint: string, factory:
 
 // given the parameters as AccountDeployer, return the resulting "counterfactual address" that it would create.
 export async function getAccountAddress (owner: string, factory: SimpleAccountFactory, salt = 0): Promise<string> {
-  return await factory.getAddress(owner, salt)
+  return await factory.getAccountAddress(owner, salt)
 }
 
 const panicCodes: { [key: number]: string } = {
@@ -299,7 +299,7 @@ export async function createAccount (
   const accountFactory = _factory ?? await new SimpleAccountFactory__factory(ethersSigner).deploy(entryPoint)
   const implementation = await accountFactory.accountImplementation()
   await accountFactory.createAccount(accountOwner, 0)
-  const accountAddress = await accountFactory.getAddress(accountOwner, 0)
+  const accountAddress = await accountFactory.getAccountAddress(accountOwner, 0)
   const proxy = SimpleAccount__factory.connect(accountAddress, ethersSigner)
   return {
     implementation,


### PR DESCRIPTION
In ethers v6, you can no longer get the address of a contract synchronously, so they've added an async `.getAddress()` method.

This means using `getAddress` as a contract method breaks the ethers API. `.getAddress` continues to return the address of the factory, and the contract method for getting the account address is inaccessible. The types generated by typechain also incorrectly show the contract method, but the JS actually resolves to ethers' `.getAddress`.

Incorrect types show custom `getAddress` defined in solidity:

![Screen Shot 2023-08-04 at 3 07 19 pm](https://github.com/eth-infinitism/account-abstraction/assets/9291586/1ab400d2-111c-4530-ab51-78818b90d99f)

Actually resolves to the ethers' builtin to get the address of the contract, regardless of the parameters passed:

![Screen Shot 2023-08-04 at 3 09 08 pm](https://github.com/eth-infinitism/account-abstraction/assets/9291586/7468096c-5850-4907-851a-a3c3a1ce9e6a)

This PR renames `getAddress` to `getAccountAddress` to fix this problem.

Passes `yarn hardhat test`.