### PR TITLE
contract interface update

### DIFF
--- a/contracts/samples/TokenPaymaster.sol
+++ b/contracts/samples/TokenPaymaster.sol
@@ -6,7 +6,7 @@ import "@openzeppelin/contracts/token/ERC20/extensions/IERC20Metadata.sol";
 import "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 import "@openzeppelin/contracts/utils/cryptography/EIP712.sol";
 
-import "../core/EntryPoint.sol";
+import "../interfaces/IEntryPoint.sol";
 import "../core/BasePaymaster.sol";
 import "./utils/UniswapHelper.sol";
 import "./utils/OracleHelper.sol";

--- a/contracts/samples/VerifyingPaymaster.sol
+++ b/contracts/samples/VerifyingPaymaster.sol
@@ -70,7 +70,7 @@ contract VerifyingPaymaster is BasePaymaster {
      * paymasterAndData[84:] : signature
      */
     function _validatePaymasterUserOp(UserOperation calldata userOp, bytes32 /*userOpHash*/, uint256 requiredPreFund)
-    internal override returns (bytes memory context, uint256 validationData) {
+    internal view override returns (bytes memory context, uint256 validationData) {
         (requiredPreFund);
 
         (uint48 validUntil, uint48 validAfter, bytes calldata signature) = parsePaymasterAndData(userOp.paymasterAndData);

--- a/contracts/test/MaliciousAccount.sol
+++ b/contracts/test/MaliciousAccount.sol
@@ -2,7 +2,6 @@
 pragma solidity ^0.8.12;
 import "../interfaces/IAccount.sol";
 import "../interfaces/IEntryPoint.sol";
-import "../core/EntryPoint.sol";
 
 contract MaliciousAccount is IAccount {
     IEntryPoint private ep;

--- a/contracts/test/TestPaymasterRevertCustomError.sol
+++ b/contracts/test/TestPaymasterRevertCustomError.sol
@@ -20,7 +20,7 @@ contract TestPaymasterRevertCustomError is BasePaymaster {
         context = abi.encodePacked(userOp.sender);
     }
 
-    function _postOp(PostOpMode mode, bytes calldata, uint256) internal override {
+    function _postOp(PostOpMode mode, bytes calldata, uint256) internal pure override {
         if(mode == PostOpMode.postOpReverted) {
             return;
         }


### PR DESCRIPTION
- removed unneeded reference to EntryPoint (instead of IEntryPoint)
- silence "view" and "pure" warnings.