### PR TITLE
Initial discussion of unused gas onchain solution

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,3 +9,4 @@ Implementation of contracts for [ERC-4337](https://eips.ethereum.org/EIPS/eip-43
 [Bundler reference implementation](https://github.com/eth-infinitism/bundler)
 
 [Bundler specification test suite](https://github.com/eth-infinitism/bundler-spec-tests)
+


### PR DESCRIPTION
Currently, a client can send a `UserOperation` with an arbitrarily high `callGasLlimit` but leaving most of it unused, in order to occupy most of the bundle gas limit. This can potenitally hurt the bundler  profitability, by making it skip other `UserOperations` due to block gas limit.
Instead of each bundler having to implement its own custom protection against such griefing attempt, we suggest the following fix in EntryPoint:

For a user operation exceeding a certain threshold (e.g. 1M gas limit): 
1.  Allow the user to have a cushion of min(50K, 0.1 * userOp.callGasLimit). If it passes that threshold, then:
2.  Charge the user extra 10% of the remaining unused gas above threshold.