### PR TITLE
chore: remove erc777

### DIFF
--- a/contracts/samples/callback/TokenCallbackHandler.sol
+++ b/contracts/samples/callback/TokenCallbackHandler.sol
@@ -1,8 +1,6 @@
 // SPDX-License-Identifier: GPL-3.0
 pragma solidity ^0.8.12;
 
-/* solhint-disable no-empty-blocks */
-
 import "@openzeppelin/contracts/utils/introspection/IERC165.sol";
 import "@openzeppelin/contracts/token/ERC721/IERC721Receiver.sol";
 import "@openzeppelin/contracts/token/ERC1155/IERC1155Receiver.sol";

--- a/contracts/samples/callback/TokenCallbackHandler.sol
+++ b/contracts/samples/callback/TokenCallbackHandler.sol
@@ -4,7 +4,6 @@ pragma solidity ^0.8.12;
 /* solhint-disable no-empty-blocks */
 
 import "@openzeppelin/contracts/utils/introspection/IERC165.sol";
-import "@openzeppelin/contracts/token/ERC777/IERC777Recipient.sol";
 import "@openzeppelin/contracts/token/ERC721/IERC721Receiver.sol";
 import "@openzeppelin/contracts/token/ERC1155/IERC1155Receiver.sol";
 
@@ -12,17 +11,7 @@ import "@openzeppelin/contracts/token/ERC1155/IERC1155Receiver.sol";
  * Token callback handler.
  *   Handles supported tokens' callbacks, allowing account receiving these tokens.
  */
-contract TokenCallbackHandler is IERC777Recipient, IERC721Receiver, IERC1155Receiver {
-    function tokensReceived(
-        address,
-        address,
-        address,
-        uint256,
-        bytes calldata,
-        bytes calldata
-    ) external pure override {
-    }
-
+contract TokenCallbackHandler is IERC721Receiver, IERC1155Receiver {
     function onERC721Received(
         address,
         address,
@@ -52,7 +41,9 @@ contract TokenCallbackHandler is IERC777Recipient, IERC721Receiver, IERC1155Rece
         return IERC1155Receiver.onERC1155BatchReceived.selector;
     }
 
-    function supportsInterface(bytes4 interfaceId) external view virtual override returns (bool) {
+    function supportsInterface(
+        bytes4 interfaceId
+    ) external view virtual override returns (bool) {
         return
             interfaceId == type(IERC721Receiver).interfaceId ||
             interfaceId == type(IERC1155Receiver).interfaceId ||


### PR DESCRIPTION
Recently OpenZeppelin upgraded contracts to v.5.0.0 and above which has removed the `ERC777` implementation. Since the AA kit still uses it, it results in conflicts.

ERC777 is an overengineered solution, more about it [here](https://github.com/OpenZeppelin/openzeppelin-contracts/issues/2620)

This PR fixes #354 and makes the kit supported out of the box without hassle of changing dependencies.