### PR TITLE
Optionally return pending UO in `eth_getUserOperationByHash`

### DIFF
--- a/eip/EIPS/eip-4337.md
+++ b/eip/EIPS/eip-4337.md
@@ -625,7 +625,14 @@ Return a UserOperation based on a hash (userOpHash) returned by `eth_sendUserOpe
 
 **Return value**:
 
-`null` in case the UserOperation is not yet included in a block, or a full UserOperation, with the addition of `entryPoint`, `blockNumber`, `blockHash` and `transactionHash`
+* If the UserOperation is included in a block:
+  * Return a full UserOperation, with the addition of `entryPoint`, `blockNumber`, `blockHash` and `transactionHash`.
+
+* Else if the UserOperation is pending in the bundler's mempool:
+  *  MAY return `null`, or: a full UserOperation, with the addition of the `entryPoint` field and a `null` value for `blockNumber`, `blockHash` and `transactionHash`.
+
+* Else:
+  * Return `null`
 
 #### * eth_getUserOperationReceipt
 


### PR DESCRIPTION
This change allows a bundler to return a non-null value for `eth_getUserOperationByHash` when the requrested UO is pending in its mempool. In this case the bundler can populate the same return object as when the UO is mined, but with `blockNumber`, `blockHash`, and `transactionHash` set to `null`.