### PR TITLE
remove unused event PostOpReverted from TokenPaymaster

### DIFF
--- a/contracts/samples/TokenPaymaster.sol
+++ b/contracts/samples/TokenPaymaster.sol
@@ -42,8 +42,6 @@ contract TokenPaymaster is BasePaymaster, UniswapHelper, OracleHelper {
 
     event UserOperationSponsored(address indexed user, uint256 actualTokenCharge, uint256 actualGasCost, uint256 actualTokenPrice);
 
-    event PostOpReverted(address indexed user, uint256 preCharge);
-
     event Received(address indexed sender, uint256 value);
 
     /// @notice All 'price' variables are multiplied by this value to avoid rounding up
@@ -151,7 +149,12 @@ contract TokenPaymaster is BasePaymaster, UniswapHelper, OracleHelper {
     /// @dev This function is called after a user operation has been executed or reverted.
     /// @param context The context containing the token amount and user sender address.
     /// @param actualGasCost The actual gas cost of the transaction.
-    function _postOp(PostOpMode, bytes calldata context, uint256 actualGasCost) internal override {
+    function _postOp(PostOpMode mode, bytes calldata context, uint256 actualGasCost) internal override {
+        // Marked for removal when using with next EP version
+        if (mode == PostOpMode.postOpReverted) {
+            return; // Do nothing here to not revert the whole bundle and harm reputation
+        }
+
         unchecked {
             uint256 priceMarkup = tokenPaymasterConfig.priceMarkup;
             (

--- a/contracts/samples/TokenPaymaster.sol
+++ b/contracts/samples/TokenPaymaster.sol
@@ -149,12 +149,7 @@ contract TokenPaymaster is BasePaymaster, UniswapHelper, OracleHelper {
     /// @dev This function is called after a user operation has been executed or reverted.
     /// @param context The context containing the token amount and user sender address.
     /// @param actualGasCost The actual gas cost of the transaction.
-    function _postOp(PostOpMode mode, bytes calldata context, uint256 actualGasCost) internal override {
-        // Marked for removal when using with next EP version
-        if (mode == PostOpMode.postOpReverted) {
-            return; // Do nothing here to not revert the whole bundle and harm reputation
-        }
-
+    function _postOp(PostOpMode, bytes calldata context, uint256 actualGasCost) internal override {
         unchecked {
             uint256 priceMarkup = tokenPaymasterConfig.priceMarkup;
             (


### PR DESCRIPTION
1. Removing the event PostOpReverted which is not being used in current paymaster. I would also like to understand reason behind [adding this](https://github.com/eth-infinitism/account-abstraction/pull/362/files) in the entry point and how to use it in paymasters. (in context of current entry point and upcoming EP)

2. Adding this back in _postOp()

```
 if (mode == PostOpMode.postOpReverted) {
            return; // Do nothing here to not revert the whole bundle and harm reputation
        }
```

since current entry point still uses postOp twice and current code will just revert twice if postOp can not transfer tokens etc. 

pre charging in validatePaymasterUserOp works but it's not a great UX to give pre approval to the paymaster as part of other userOp sponsored by some other paymaster. instead of that dapps would prefer limited approvals given as part of each calldata (based on fee quotes) 

in new entry point with [this](https://github.com/eth-infinitism/account-abstraction/pull/311) it would change couple of things again regarding UX of token paymaster. 
