### PR TITLE
simulation deposit must be more expensive

### DIFF
--- a/contracts/core/EntryPointSimulations.sol
+++ b/contracts/core/EntryPointSimulations.sol
@@ -167,7 +167,8 @@ contract EntryPointSimulations is EntryPoint, IEntryPointSimulations {
         revert("");
     }
 
-    //make sure depositTo cost is more than normal EntryPoint's cost.
+    //make sure depositTo cost is more than normal EntryPoint's cost,
+    // to mitigate DoS vector on the bundler
     // empiric test showed that without this wrapper, simulation depositTo costs less..
     function depositTo(address account) public override(IStakeManager, StakeManager) payable {
         unchecked{

--- a/test/entrypointsimulations.test.ts
+++ b/test/entrypointsimulations.test.ts
@@ -47,6 +47,8 @@ describe('EntryPointSimulations', function () {
   })
 
   describe('Simulation Contract Sanity checks', () => {
+    // validate that successful simulation is always successful on real entrypoint,
+    // regardless of "environment" parameters (like gaslimit)
     const addr = createAddress()
 
     // coverage skews gas checks.


### PR DESCRIPTION
Document that depositTo must be more expensive during simulation
Otherwise, it opens a DoS vector on bundlers.