### PR TITLE
adds openzeppelin to the contracts/package.json [for ver0.6.0]

### DIFF
--- a/contracts/package.json
+++ b/contracts/package.json
@@ -26,6 +26,7 @@
   "devDependencies": {
     "@gnosis.pm/safe-contracts": "^1.3.0",
     "@nomiclabs/hardhat-ethers": "^2.0.2",
-    "@nomiclabs/hardhat-waffle": "^2.0.1"
+    "@nomiclabs/hardhat-waffle": "^2.0.1",
+    "@openzeppelin/contracts": "^4.2.0"
   }
 }


### PR DESCRIPTION
when installing the @accounts-abstraction/contracts [via the npm package](https://www.npmjs.com/package/@account-abstraction/contracts), it cannot compile until openzeppelin is installed as well