### PR TITLE
fix(debug): use hex for reputation fields in debug namespace

### DIFF
--- a/erc/ERCS/erc-4337.md
+++ b/erc/ERCS/erc-4337.md
@@ -846,7 +846,6 @@ Sets reputation of given addresses. parameters:
   * `address` - The address to set the reputation for.
   * `opsSeen` - number of times a user operations with that entity was seen and added to the mempool
   * `opsIncluded` - number of times a user operations that uses this entity was included on-chain
-  * `status` - (string) The status of the address in the bundler 'ok' | 'throttled' | 'banned'.
 
 * **EntryPoint** the entrypoint used by eth_sendUserOperation
 
@@ -860,8 +859,8 @@ Sets reputation of given addresses. parameters:
     [
       {
         "address": "0x7A0A0d159218E6a2f407B99173A2b12A6DDfC2a6",
-        "opsSeen": 20,
-        "opsIncluded": 13
+        "opsSeen": "0x14",
+        "opsIncluded": "0x0D"
       }
     ],
     "0x1306b01bC3e4AD202612D3843387e94737673F53"
@@ -911,8 +910,8 @@ An array of reputation entries with the fields:
   "id": 1,
   "result": [
     { "address": "0x7A0A0d159218E6a2f407B99173A2b12A6DDfC2a6",
-      "opsSeen": 20,
-      "opsIncluded": 19,
+      "opsSeen": "0x14",
+      "opsIncluded": "0x13",
       "status": "ok"
     }
   ]


### PR DESCRIPTION
Changes:
- `status` is not supplied in the `debug_bundler_setReputation` API.
- `opsSeen` and `opsIncluded` should be formatted as hex.
  - See https://github.com/eth-infinitism/bundler-spec/blob/c249743b69c985f7f20c3ecbe83e56cc79925c95/src/schemas/bundle.yaml#L32 