### PR TITLE
fix: allow _senderCreator to be overridden

### DIFF
--- a/contracts/core/EntryPointSimulations.sol
+++ b/contracts/core/EntryPointSimulations.sol
@@ -16,7 +16,7 @@ contract EntryPointSimulations is EntryPoint, IEntryPointSimulations {
     // solhint-disable-next-line var-name-mixedcase
     AggregatorStakeInfo private NOT_AGGREGATED = AggregatorStakeInfo(address(0), StakeInfo(0, 0));
 
-    SenderCreator private _senderCreator;
+    SenderCreator _senderCreator;
 
     function initSenderCreator() internal virtual {
         //this is the address of the first contract created with CREATE by this address.


### PR DESCRIPTION
This is useful when overriding the virtual function `initSenderCreator`. One usecase is to pass a different address then `address(this)` in order to calculate the address of the `SenderCreator`, for example when using Foundry's `etch` to move the EntryPoint to a different address.