### PR TITLE
fix: debug_bundler_dumpReputation status type

### DIFF
--- a/erc/ERCS/erc-4337.md
+++ b/erc/ERCS/erc-4337.md
@@ -946,7 +946,7 @@ An array of reputation entries with the fields:
 * `address` - The address to set the reputation for.
 * `opsSeen` - number of times a user operations with that entity was seen and added to the mempool
 * `opsIncluded` - number of times a user operations that uses this entity was included on-chain
-* `status` - (string) The status of the address in the bundler 'ok' | 'throttled' | 'banned'.
+* `status` - (number) The status of the address in the bundler 0 = 'ok' | 1 = 'throttled' | 2 = 'banned'.
 
 ```json=
 # Request
@@ -965,7 +965,7 @@ An array of reputation entries with the fields:
     { "address": "0x7A0A0d159218E6a2f407B99173A2b12A6DDfC2a6",
       "opsSeen": "0x14",
       "opsIncluded": "0x13",
-      "status": "ok"
+      "status": "0x0"
     }
   ]
 }


### PR DESCRIPTION
Changed debug_bundler_dumpReputation `status` to `number` instead of `string` as per [spec-tests](https://github.com/eth-infinitism/bundler-spec-tests/blob/master/tests/single/reputation/test_reputation.py#L20-L23)