### PR TITLE
fix: token paymaster decimal bug

### DIFF
--- a/contracts/samples/TokenPaymaster.sol
+++ b/contracts/samples/TokenPaymaster.sol
@@ -139,7 +139,12 @@ contract TokenPaymaster is BasePaymaster, UniswapHelper, OracleHelper {
                     cachedPriceWithMarkup = clientSuppliedPrice;
                 }
             }
-            uint256 tokenAmount = weiToToken(preChargeNative, cachedPriceWithMarkup);
+            uint8 tokenDecimals = token.decimals();
+            uint256 tokenAmount = weiToToken(
+                preChargeNative, 
+                tokenDecimals,
+                cachedPriceWithMarkup
+            );
             SafeERC20.safeTransferFrom(token, userOp.sender, address(this), tokenAmount);
             context = abi.encode(tokenAmount, userOp.sender);
             validationResult = _packValidationData(
@@ -169,7 +174,12 @@ contract TokenPaymaster is BasePaymaster, UniswapHelper, OracleHelper {
             uint256 cachedPriceWithMarkup = _cachedPrice * PRICE_DENOMINATOR / priceMarkup;
         // Refund tokens based on actual gas cost
             uint256 actualChargeNative = actualGasCost + tokenPaymasterConfig.refundPostopCost * actualUserOpFeePerGas;
-            uint256 actualTokenNeeded = weiToToken(actualChargeNative, cachedPriceWithMarkup);
+            uint8 tokenDecimals = token.decimals();
+            uint256 actualTokenNeeded = weiToToken(
+                actualChargeNative,
+                tokenDecimals,
+                cachedPriceWithMarkup
+            );
             if (preCharge > actualTokenNeeded) {
                 // If the initially provided token amount is greater than the actual amount needed, refund the difference
                 SafeERC20.safeTransfer(

--- a/test/samples/OracleHelper.test.ts
+++ b/test/samples/OracleHelper.test.ts
@@ -63,7 +63,7 @@ describe('OracleHelper', function () {
     it('should figure out the correct price', async function () {
       await testEnv.paymaster.updateCachedPrice(true)
       const cachedPrice = await testEnv.paymaster.cachedPrice()
-      const tokensPerEtherCalculated = await testEnv.paymaster.weiToToken(parseEther('1'), cachedPrice)
+      const tokensPerEtherCalculated = await testEnv.paymaster.weiToToken(parseEther('1'), 18, cachedPrice)
       assert.equal(cachedPrice.toString(), testEnv.expectedPrice.toString(), 'price not right')
       assert.equal(tokensPerEtherCalculated.toString(), testEnv.expectedTokensPerEtherCalculated.toString(), 'tokens amount not right')
     })


### PR DESCRIPTION
# Summary

When I tried the latest `TokenPaymaster` in sample, I noticed that it only considers the case of token's decimal being 18, which will cause amount calculation error. This PR fixes this issue by querying the token's decimals when calculating the token amount to transfer to/from paymaster