### PR TITLE
Update `actualGasCost` description.

### DIFF
--- a/contracts/interfaces/IPaymaster.sol
+++ b/contracts/interfaces/IPaymaster.sol
@@ -49,7 +49,7 @@ interface IPaymaster {
      *                        opReverted  - User op reverted. The paymaster still has to pay for gas.
      *                        postOpReverted - never passed in a call to postOp().
      * @param context       - The context value returned by validatePaymasterUserOp
-     * @param actualGasCost - Actual gas used so far (without this postOp call).
+     * @param actualGasCost - The actual cost of this transaction so far (without this postOp call).
      * @param actualUserOpFeePerGas - the gas price this UserOp pays. This value is based on the UserOp's maxFeePerGas
      *                        and maxPriorityFee (and basefee)
      *                        It is not the same as tx.gasprice, which is what the bundler pays.


### PR DESCRIPTION
Origin description of `actualGasCost` makes developers easy to think it as `actualGas`. However, it is actually the `actualGasCost = actualGas * gasPrice`.
```
* @param actualGasCost - Actual gas used so far (without this postOp call).
```

Referring to the description of `maxCost`, I update the `actualGasCost` description.
```
* @param maxCost         - The maximum cost of this transaction (based on maximum gas and gas price from userOp).
```
```
* @param actualGasCost - The actual cost of this transaction so far (without this postOp call).
```