### PR TITLE
Fix parameters list for eth_sendUserOperation

### DIFF
--- a/erc/ERCS/erc-4337.md
+++ b/erc/ERCS/erc-4337.md
@@ -553,9 +553,7 @@ The result `SHOULD` be set to the **userOpHash** if and only if the request pass
 ##### Parameters:
 
 1. **UserOperation** a full user-operation struct. All fields MUST be set as hex values. empty `bytes` block (e.g. empty `initCode`) MUST be set to `"0x"`
-2. **factory** and **factoryData** - either both exist, or none
-3. paymaster fields (**paymaster**, **paymasterData**, **paymasterValidationGasLimit**, **paymasterPostOpGasLimit**) either all exist, or none.
-4. **EntryPoint** the entrypoint address the request should be sent through. this MUST be one of the entry points returned by the `supportedEntryPoints` rpc call.
+2. **EntryPoint** the entrypoint address the request should be sent through. this MUST be one of the entry points returned by the `supportedEntryPoints` rpc call.
 
 ##### Return value:
 


### PR DESCRIPTION
Noticed `factory` and `paymaster` fields are listed as parameters for `eth_sendUserOperation`. Assuming this is a mistake since they would already be encoded in `UserOperation`.