### PR TITLE
Packed int values should be defined as uint128 to prevent overflow

### DIFF
--- a/erc/ERCS/erc-4337.md
+++ b/erc/ERCS/erc-4337.md
@@ -62,14 +62,14 @@ To avoid Ethereum consensus changes, we do not attempt to create new transaction
 | `factory`                       | `address` | account factory, only for new accounts                                         |
 | `factoryData`                   | `bytes`   | data for account factory (only if account factory exists)                      |
 | `callData`                      | `bytes`   | The data to pass to the `sender` during the main execution call                |
-| `callGasLimit`                  | `uint256` | The amount of gas to allocate the main execution call                          |
-| `verificationGasLimit`          | `uint256` | The amount of gas to allocate for the verification step                        |
+| `callGasLimit`                  | `uint128` | The amount of gas to allocate the main execution call                          |
+| `verificationGasLimit`          | `uint128` | The amount of gas to allocate for the verification step                        |
 | `preVerificationGas`            | `uint256` | Extra gas to pay the bunder                                                    |
-| `maxFeePerGas`                  | `uint256` | Maximum fee per gas (similar to [EIP-1559](./eip-1559.md) `max_fee_per_gas`)   |
-| `maxPriorityFeePerGas`          | `uint256` | Maximum priority fee per gas (similar to EIP-1559 `max_priority_fee_per_gas`)  |
+| `maxFeePerGas`                  | `uint128` | Maximum fee per gas (similar to [EIP-1559](./eip-1559.md) `max_fee_per_gas`)   |
+| `maxPriorityFeePerGas`          | `uint128` | Maximum priority fee per gas (similar to EIP-1559 `max_priority_fee_per_gas`)  |
 | `paymaster`                     | `address` | Address of paymaster contract, (or empty, if account pays for itself)          |
-| `paymasterVerificationGasLimit` | `uint256` | The amount of gas to allocate for the paymaster validation code                |
-| `paymasterPostOpGasLimit`       | `uint256` | The amount of gas to allocate for the paymaster post-operation code            |
+| `paymasterVerificationGasLimit` | `uint128` | The amount of gas to allocate for the paymaster validation code                |
+| `paymasterPostOpGasLimit`       | `uint128` | The amount of gas to allocate for the paymaster post-operation code            |
 | `paymasterData`                 | `bytes`   | Data for paymaster (only if paymaster exists)                                  |
 | `signature`                     | `bytes`   | Data passed into the account to verify authorization                           |
 
@@ -80,17 +80,17 @@ To prevent replay attacks (both cross-chain and multiple `EntryPoint` implementa
 
 When passed to on-chain contacts (the EntryPoint contract, and then to account and paymaster), a packed version of the above structure is used:
 
-| Field                | Type      | Description                                                            |
-|----------------------|-----------|------------------------------------------------------------------------|
-| `sender`             | `address` |                                                                        |
-| `nonce`              | `uint256` |                                                                        |
-| `initCode`           | `bytes`   | concatenation of factory address and factoryData (or empty)            |
-| `callData`           | `bytes`   |                                                                        |
-| `accountGasLimits`   | `bytes32` | concatenation of verificationGas (16 bytes) and callGas (16 bytes)     |
-| `preVerificationGas` | `uint256` |                                                                        |
-| `gasFees`            | `bytes32` | concatenation of maxPriorityFee (16 bytes) and maxFeePerGas (16 bytes) |
-| `paymasterAndData`   | `bytes`   | concatenation of paymaster fields (or empty)                           |
-| `signature`          | `bytes`   |                                                                        |
+| Field                | Type      | Description                                                                                                                          |
+| -------------------- | --------- | ------------------------------------------------------------------------------------------------------------------------------------ |
+| `sender`             | `address` |                                                                                                                                      |
+| `nonce`              | `uint256` |                                                                                                                                      |
+| `initCode`           | `bytes`   | concatenation of factory address and factoryData (or empty)                                                                          |
+| `callData`           | `bytes`   |                                                                                                                                      |
+| `accountGasLimits`   | `bytes32` | concatenation of verificationGas (16 bytes) and callGas (16 bytes)                                                                   |
+| `preVerificationGas` | `uint256` |                                                                                                                                      |
+| `gasFees`            | `bytes32` | concatenation of maxPriorityFee (16 bytes) and maxFeePerGas (16 bytes)                                                               |
+| `paymasterAndData`   | `bytes`   | concatenation of paymaster, paymasterVerificationGasLimit (16 bytes), paymasterPostOpGasLimit(16 bytes) and paymasterData (or empty) |
+| `signature`          | `bytes`   |                                                                                                                                      |
 
 
 The core interface of the entry point contract is as follows:


### PR DESCRIPTION
Since all gas related values (with the exception of `preVerificationGas`) are capped to 16 bytes in a `PackedUserOperation`, should these values be defined as type `uint128` in a `UserOperation`?