### PR TITLE
Docs improvement

### DIFF
--- a/contracts/core/BaseAccount.sol
+++ b/contracts/core/BaseAccount.sol
@@ -96,7 +96,7 @@ abstract contract BaseAccount is IAccount {
      * SubClass MAY override this method for better funds management
      * (e.g. send to the entryPoint more than the minimum required, so that in future transactions
      * it will not be required to send again).
-     * @param missingAccountFunds - The minimum value this method should send the entrypoint.
+     * @param missingAccountFunds - The minimum value this method should send to the entrypoint.
      *                              This value MAY be zero, in case there is enough deposit,
      *                              or the userOp has a paymaster.
      */

--- a/contracts/core/BasePaymaster.sol
+++ b/contracts/core/BasePaymaster.sol
@@ -119,7 +119,7 @@ abstract contract BasePaymaster is IPaymaster, Ownable {
     }
 
     /**
-     * Return current paymaster's deposit on the entryPoint.
+     * Return the current paymaster's deposit on the entryPoint.
      */
     function getDeposit() public view returns (uint256) {
         return entryPoint.balanceOf(address(this));

--- a/contracts/core/EntryPoint.sol
+++ b/contracts/core/EntryPoint.sol
@@ -20,7 +20,7 @@ import "@openzeppelin/contracts/utils/ReentrancyGuard.sol";
 
 /*
  * Account-Abstraction (EIP-4337) singleton EntryPoint implementation.
- * Only one instance required on each chain.
+ * Only one instance is required on each chain.
  */
 
 /// @custom:security-contact https://bounty.ethereum.org

--- a/contracts/core/EntryPointSimulations.sol
+++ b/contracts/core/EntryPointSimulations.sol
@@ -178,7 +178,7 @@ contract EntryPointSimulations is EntryPoint, IEntryPointSimulations {
     // empiric test showed that without this wrapper, simulation depositTo costs less..
     function depositTo(address account) public override(IStakeManager, StakeManager) payable {
         unchecked{
-        // silly code, to waste some gas to make sure depositTo is always little more
+        // silly code, to waste some gas to make sure depositTo is always a little more
         // expensive than on-chain call
             uint256 x = 1;
             while (x < 5) {

--- a/contracts/core/StakeManager.sol
+++ b/contracts/core/StakeManager.sol
@@ -67,7 +67,7 @@ abstract contract StakeManager is IStakeManager {
 
     /**
      * Add to the account's stake - amount and delay
-     * any pending unstake is first cancelled.
+     * any pending unstake is first canceled.
      * @param unstakeDelaySec The new lock duration before the deposit can be withdrawn.
      */
     function addStake(uint32 unstakeDelaySec) public payable {

--- a/contracts/core/UserOperationLib.sol
+++ b/contracts/core/UserOperationLib.sol
@@ -7,7 +7,7 @@ import "../interfaces/PackedUserOperation.sol";
 import {calldataKeccak, min} from "./Helpers.sol";
 
 /**
- * Utility functions helpful when working with UserOperation structs.
+ * Utility functions are helpful when working with UserOperation structs.
  */
 library UserOperationLib {
 

--- a/contracts/interfaces/IAccount.sol
+++ b/contracts/interfaces/IAccount.sol
@@ -14,7 +14,7 @@ interface IAccount {
      * @dev Must validate caller is the entryPoint.
      *      Must validate the signature and nonce
      * @param userOp              - The operation that is about to be executed.
-     * @param userOpHash          - Hash of the user's request data. can be used as the basis for signature.
+     * @param userOpHash          - Hash of the user's requested data. can be used as the basis for signature.
      * @param missingAccountFunds - Missing funds on the account's deposit in the entrypoint.
      *                              This is the minimum amount to transfer to the sender(entryPoint) to be
      *                              able to make the call. The excess is left as a deposit in the entrypoint

--- a/contracts/interfaces/IAggregator.sol
+++ b/contracts/interfaces/IAggregator.sol
@@ -34,7 +34,7 @@ interface IAggregator {
     /**
      * Aggregate multiple signatures into a single value.
      * This method is called off-chain to calculate the signature to pass with handleOps()
-     * bundler MAY use optimized custom code perform this aggregation.
+     * bundler MAY use optimized custom code to perform this aggregation.
      * @param userOps              - Array of UserOperations to collect the signatures from.
      * @return aggregatedSignature - The aggregated signature.
      */

--- a/contracts/interfaces/IEntryPointSimulations.sol
+++ b/contracts/interfaces/IEntryPointSimulations.sol
@@ -53,7 +53,7 @@ interface IEntryPointSimulations is IEntryPoint {
      * It performs full validation of the UserOperation, but ignores signature error.
      * An optional target address is called after the userop succeeds,
      * and its value is returned (before the entire call is reverted).
-     * Note that in order to collect the the success/failure of the target call, it must be executed
+     * Note that in order to collect the success/failure of the target call, it must be executed
      * with trace enabled to track the emitted events.
      * @param op The UserOperation to simulate.
      * @param target         - If nonzero, a target address to call after userop simulation. If called,

--- a/contracts/samples/utils/OracleHelper.sol
+++ b/contracts/samples/utils/OracleHelper.sol
@@ -9,7 +9,7 @@ import "./IOracle.sol";
 /// @notice Maintains a price cache and updates the current price if needed.
 /// In the best case scenario we have a direct oracle from the token to the native asset.
 /// Also support tokens that have no direct price oracle to the native asset.
-/// Sometimes oracles provide the price in the opposite direction of what we need in the moment.
+/// Sometimes oracles provide the price in the opposite direction of what we need at the moment.
 abstract contract OracleHelper {
 
     event TokenPriceUpdated(uint256 currentPrice, uint256 previousPrice, uint256 cachedPriceTimestamp);

--- a/contracts/samples/utils/UniswapHelper.sol
+++ b/contracts/samples/utils/UniswapHelper.sol
@@ -28,7 +28,7 @@ abstract contract UniswapHelper {
     /// @notice The ERC20 token used for transaction fee payments
     IERC20 public immutable token;
 
-    /// @notice The ERC-20 token that wraps the native asset for current chain
+    /// @notice The ERC-20 token that wraps the native asset for the current chain
     IERC20 public immutable wrappedNative;
 
     UniswapHelperConfig private uniswapHelperConfig;


### PR DESCRIPTION
Rectify typographical inaccuracies

This PR addresses several typographical errors across various files in the project. The changes improve readability and maintain the professional standard of the documentation and code comments.

Justification
Typographical errors, while minor, can detract from the overall quality of the project. Correcting these errors ensures clarity and professionalism, making the project more accessible and understandable for current and future contributors.