### PR TITLE
Allows Bundler to be the paymaster without Paymaster contract

### DIFF
--- a/contracts/core/EntryPoint.sol
+++ b/contracts/core/EntryPoint.sol
@@ -482,7 +482,7 @@ contract EntryPoint is IEntryPoint, StakeManager, NonceManager, ReentrancyGuard,
             uint256 missingAccountFunds = 0;
             if (paymaster == address(0)) {
                 uint256 bal = balanceOf(sender);
-                missingAccountFunds = bal > requiredPrefund
+                missingAccountFunds = bal >= requiredPrefund
                     ? 0
                     : requiredPrefund - bal;
             }


### PR DESCRIPTION
Currently, how the ``balance`` is checked against the ``requiredPreFund`` value does not allow the Bundler itself to fund the execution without having a paymaster contract involved. Also, it will increase the readability and correctness. 