### PR TITLE
 Improve Clarity in Documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Implementation of contracts for [ERC-4337](https://eips.ethereum.org/EIPS/eip-43
 
 [Vitalik's post on account abstraction without Ethereum protocol changes](https://medium.com/infinitism/erc-4337-account-abstraction-without-ethereum-protocol-changes-d75c9d94dc4a)
 
-[Discord server](http://discord.gg/fbDyENb6Y9)
+[Join the Discord server](http://discord.gg/fbDyENb6Y9)
 
 [Bundler reference implementation](https://github.com/eth-infinitism/bundler)
 


### PR DESCRIPTION
Description: This PR addresses an issue with the clarity of the invitation to the Discord server:

Replaced "Discord server" with "Join the Discord server" to clearly indicate that it is an invitation and not just a description.
Why it’s useful: This change makes the sentence more direct and inviting, improving the user experience by clearly signaling that the user is being invited to join the Discord server, rather than just being provided with a mention of it.

