### PR TITLE
Fix Test Descriptions for Clarity and Consistency

### DIFF
--- a/test/entrypoint.test.ts
+++ b/test/entrypoint.test.ts
@@ -181,7 +181,7 @@ describe('EntryPoint', function () {
             withdrawTime: withdrawTime1
           })
         })
-        it('should fail to withdraw before unlock timeout', async () => {
+        it('should fail to withdraw before the unlock timeout', async () => {
           await expect(entryPoint.withdrawStake(AddressZero)).to.revertedWith('Stake withdrawal is not due')
         })
         it('should fail to unlock again', async () => {

--- a/test/entrypointsimulations.test.ts
+++ b/test/entrypointsimulations.test.ts
@@ -231,7 +231,7 @@ describe('EntryPointSimulations', function () {
       await simulateValidation(op1, entryPoint.address)
     })
 
-    it('should not call initCode from entrypoint', async () => {
+    it('should not call initCode from the entrypoint', async () => {
       // a possible attack: call an account's execFromEntryPoint through initCode. This might lead to stolen funds.
       const { proxy: account } = await createAccount(ethersSigner, await accountOwner.getAddress(), entryPoint.address)
       const sender = createAddress()
@@ -312,13 +312,13 @@ describe('EntryPointSimulations', function () {
         }
       })
 
-      it('should revert with AA2x if verificationGasLimit is low', async function () {
+      it('should revert with AA2x if the verificationGasLimit is low', async function () {
         expect(await simulateValidation(packUserOp(await userOpWithGas(vgl - 1, pmVgl)), entryPoint.address)
           .catch(decodeRevertReason))
           .to.match(/AA26/)
       })
       if (withPaymaster === 'with') {
-        it('should revert with AA3x if paymasterVerificationGasLimit is low', async function () {
+        it('should revert with AA3x if the paymasterVerificationGasLimit is low', async function () {
           expect(await simulateValidation(packUserOp(await userOpWithGas(vgl, pmVgl - 1)), entryPoint.address)
             .catch(decodeRevertReason))
             .to.match(/AA36/)

--- a/test/simple-wallet.test.ts
+++ b/test/simple-wallet.test.ts
@@ -93,7 +93,7 @@ describe('SimpleAccount', function () {
     let expectedPay: number
 
     const actualGasPrice = 1e9
-    // for testing directly validateUserOp, we initialize the account with EOA as entryPoint.
+    // for testing directly validateUserOp, we initialize the account with an EOA as the entryPoint.
     let entryPointEoa: string
 
     before(async () => {


### PR DESCRIPTION
Changes:
"should fail to withdraw before unlock timeout" → "should fail to withdraw before the unlock timeout".
"should not call initCode from entrypoint" → "should not call initCode from the entrypoint".
"should revert with AA3x if paymasterVerificationGasLimit is low" → "should revert with AA3x if the paymasterVerificationGasLimit is low".
"for testing directly validateUserOp, we initialize the account with EOA as entryPoint" → "for testing directly validateUserOp, we initialize the account with an EOA as the entryPoint".
These changes were made to improve clarity, readability, and correctness in the test descriptions.





