### PR TITLE
Use SIG_VALIDATION_SUCCESS and update return value of `isValidSignature()`

### DIFF
--- a/contracts/accounts/Simple7702Account.sol
+++ b/contracts/accounts/Simple7702Account.sol
@@ -29,11 +29,11 @@ contract Simple7702Account is BaseAccount, IERC165, IERC1271, ERC1155Holder, ERC
         bytes32 userOpHash
     ) internal virtual override returns (uint256 validationData) {
 
-        return _checkSignature(userOpHash, userOp.signature) ? 0 : SIG_VALIDATION_FAILED;
+        return _checkSignature(userOpHash, userOp.signature) ? SIG_VALIDATION_SUCCESS : SIG_VALIDATION_FAILED;
     }
 
     function isValidSignature(bytes32 hash, bytes memory signature) public view returns (bytes4 magicValue) {
-        return _checkSignature(hash, signature) ? this.isValidSignature.selector : bytes4(0);
+        return _checkSignature(hash, signature) ? this.isValidSignature.selector : 0xffffffff;
     }
 
     function _checkSignature(bytes32 hash, bytes memory signature) internal view returns (bool) {

--- a/contracts/accounts/Simple7702Account.sol
+++ b/contracts/accounts/Simple7702Account.sol
@@ -33,7 +33,7 @@ contract Simple7702Account is BaseAccount, IERC165, IERC1271, ERC1155Holder, ERC
     }
 
     function isValidSignature(bytes32 hash, bytes memory signature) public view returns (bytes4 magicValue) {
-        return _checkSignature(hash, signature) ? this.isValidSignature.selector : 0xffffffff;
+        return _checkSignature(hash, signature) ? this.isValidSignature.selector : bytes4(0xffffffff);
     }
 
     function _checkSignature(bytes32 hash, bytes memory signature) internal view returns (bool) {


### PR DESCRIPTION
1. Changed the return value `0` to `SIG_VALIDATION_SUCCESS` on successful signature verification in `_validateSignature()`.  

2. Updated the return value in `isValidSignature()` on verification failure from `0` to `0xffffffff` (referencing ERC-1271 reference implementation code).