### PR TITLE
fix: query UserOperationEvent from specific block only

### DIFF
--- a/src/runop.ts
+++ b/src/runop.ts
@@ -99,9 +99,8 @@ import { TransactionReceipt } from '@ethersproject/abstract-provider/src.ts/inde
   console.log('2nd run:', await evInfo(rcpt2))
 
   async function evInfo (rcpt: TransactionReceipt): Promise<any> {
-    // TODO: checking only latest block...
     const block = rcpt.blockNumber
-    const ev = await entryPoint.queryFilter(entryPoint.filters.UserOperationEvent(), block)
+    const ev = await entryPoint.queryFilter(entryPoint.filters.UserOperationEvent(), block, block)
     // if (ev.length === 0) return {}
     return ev.map(event => {
       const { nonce, actualGasUsed } = event.args


### PR DESCRIPTION
Fixed TODO: ensure UserOperationEvent queries are restricted to the specific transaction block.

Previously queryFilter(filter, block) would search from block to latest, now uses queryFilter(filter, block, block) to query only the target block.