### PR TITLE
Fix accounts for gas estimation

### DIFF
--- a/contracts/accounts/Simple7702Account.sol
+++ b/contracts/accounts/Simple7702Account.sol
@@ -33,7 +33,6 @@ contract Simple7702Account is BaseAccount, IERC165, IERC1271, ERC1155Holder, ERC
         PackedUserOperation calldata userOp,
         bytes32 userOpHash
     ) internal virtual override returns (uint256 validationData) {
-
         return _checkSignature(userOpHash, userOp.signature) ? SIG_VALIDATION_SUCCESS : SIG_VALIDATION_FAILED;
     }
 
@@ -42,7 +41,7 @@ contract Simple7702Account is BaseAccount, IERC165, IERC1271, ERC1155Holder, ERC
     }
 
     function _checkSignature(bytes32 hash, bytes memory signature) internal view returns (bool) {
-        return ECDSA.recover(hash, signature) == address(this);
+        return signature.length == 65 && ECDSA.recover(hash, signature) == address(this);
     }
 
     function _requireForExecute() internal view virtual override {

--- a/contracts/accounts/SimpleAccount.sol
+++ b/contracts/accounts/SimpleAccount.sol
@@ -89,10 +89,14 @@ contract SimpleAccount is BaseAccount, TokenCallbackHandler, UUPSUpgradeable, In
     /// implement template method of BaseAccount
     function _validateSignature(PackedUserOperation calldata userOp, bytes32 userOpHash)
     internal override virtual returns (uint256 validationData) {
+        // bundler sets the signature as empty when estimating gas
+        if (userOp.signature.length != 65)
+            return SIG_VALIDATION_FAILED;
 
         // UserOpHash can be generated using eth_signTypedData_v4
         if (owner != ECDSA.recover(userOpHash, userOp.signature))
             return SIG_VALIDATION_FAILED;
+
         return SIG_VALIDATION_SUCCESS;
     }
 


### PR DESCRIPTION
Hey, while testing out the provided account implementations, I've noticed that it's impossible to estimate gas with them. This is because during the estimation, bundler sets the user operation signature as empty (to `0x`) and the `ECDSA.recover()` function call reverts with the error "InvalidSignatureLength".

I've added a very quick fix to address this issue.