### PR TITLE
feat: add _packValidationDataBlockRange helper (fixes silent block-deadline degradation)

### DIFF
--- a/contracts/core/Helpers.sol
+++ b/contracts/core/Helpers.sol
@@ -87,6 +87,39 @@ function _packValidationData(
         (uint256(validAfter) << (160 + 48));
 }
 
+/*
+ * The top bit of validAfter/validUntil marks the range as block numbers instead of
+ * timestamps. The EntryPoint applies block-range semantics only when BOTH bounds carry
+ * the flag.
+ */
+uint48 constant VALIDITY_BLOCK_RANGE_FLAG = 0x800000000000;
+uint48 constant VALIDITY_BLOCK_RANGE_MASK = 0x7fffffffffff;
+
+/**
+ * Helper to pack the return value for validateUserOp, using a block-number validity
+ * range instead of a timestamp range.
+ * Both bounds are always flagged: packing a flagged validUntil with an unflagged
+ * validAfter (e.g. 0 for "no start bound") silently falls back to timestamp semantics,
+ * turning a block deadline into validity for millions of years.
+ * @param sigFailed  - True for signature failure, false for success.
+ * @param validUntilBlock - Last block this operation is valid at, or 0 for "indefinitely".
+ * @param validAfterBlock - First block this UserOperation is valid at, or 0 for "no bound".
+ * @return the packed validation data.
+ */
+function _packValidationDataBlockRange(
+    bool sigFailed,
+    uint48 validUntilBlock,
+    uint48 validAfterBlock
+) pure returns (uint256) {
+    if (validUntilBlock == 0) {
+        validUntilBlock = VALIDITY_BLOCK_RANGE_MASK;
+    }
+    return
+        (sigFailed ?  SIG_VALIDATION_FAILED : SIG_VALIDATION_SUCCESS) |
+        (uint256(validUntilBlock | VALIDITY_BLOCK_RANGE_FLAG) << 160) |
+        (uint256(validAfterBlock | VALIDITY_BLOCK_RANGE_FLAG) << (160 + 48));
+}
+
 /**
  * keccak function over calldata.
  * @dev copy calldata into memory, do keccak and drop allocated memory. Strangely, this is more efficient than letting solidity do it.

--- a/contracts/test/TestHelpers.sol
+++ b/contracts/test/TestHelpers.sol
@@ -17,6 +17,10 @@ contract TestHelpers {
         return _packValidationData(sigFailed, validUntil, validAfter);
     }
 
+    function packValidationDataBlockRange(bool sigFailed, uint48 validUntilBlock, uint48 validAfterBlock) public pure returns (uint256) {
+        return _packValidationDataBlockRange(sigFailed, validUntilBlock, validAfterBlock);
+    }
+
     function getPaymasterSignatureLength(
         bytes calldata paymasterAndData
     ) public pure returns (uint256 paymasterSignatureLength) {

--- a/test/helpers.test.ts
+++ b/test/helpers.test.ts
@@ -47,4 +47,25 @@ describe('#ValidationData helpers', function () {
     expect(hexlify(await helpers.packValidationDataStruct({ aggregator: addr, validUntil: 234, validAfter: 567 })))
       .to.eql(hexlify(packValidationData({ aggregator: addr, validUntil: 234, validAfter: 567 })))
   })
+
+  it('#packValidationDataBlockRange', async () => {
+    const FLAG = '0x800000000000'
+    const MASK = 0x7fffffffffff
+    const extract = (packed: any, shift: number) =>
+      ethers.BigNumber.from(packed).shr(shift).and(0xffffffffffff).toHexString()
+
+    // both bounds must carry the flag, even when a bound is 0 ("no bound") —
+    // an unflagged bound silently degrades the whole range to timestamp semantics
+    const packed = await helpers.packValidationDataBlockRange(false, 1000, 0)
+    expect(extract(packed, 160)).to.eql(ethers.BigNumber.from(FLAG).or(1000).toHexString())
+    expect(extract(packed, 208)).to.eql(FLAG)
+
+    // sigFailed flag is preserved
+    const packedFailed = await helpers.packValidationDataBlockRange(true, 1000, 0)
+    expect(ethers.BigNumber.from(packedFailed).and(1)).to.eql(1)
+
+    // 0 deadline maps to an open-ended block range, mirroring the timestamp convention
+    const packedOpen = await helpers.packValidationDataBlockRange(false, 0, 5)
+    expect(extract(packedOpen, 160)).to.eql(ethers.BigNumber.from(FLAG).or(MASK).toHexString())
+  })
 })


### PR DESCRIPTION
## Summary

- `EntryPoint._getValidationData` applies block-number validity **only when both** `validAfter` and `validUntil` carry `VALIDITY_BLOCK_RANGE_FLAG`; otherwise the values are read as timestamps.
- No packing helper exists for block ranges. The natural hand-rolled encoding for *"valid until block N, no start bound"* — `validUntil = FLAG|N`, `validAfter = 0` — fails the both-bounds check, so `FLAG|N` (~140 trillion) is read as a **timestamp** and the UserOp stays valid for ~4.4 million years instead of until block N.
- Add `_packValidationDataBlockRange(sigFailed, validUntilBlock, validAfterBlock)` which always flags both bounds, and maps a zero deadline to an open-ended block range (mirroring the timestamp `0 = indefinitely` convention).

## Impact if unsolved

Accounts/paymasters encoding block deadlines with no start bound — e.g. "this intent is only valid for the next 100 blocks" — get silent unlimited validity: a signature intended to die at block N remains executable indefinitely if leaked or front-run later.

## Test plan

- New `#packValidationDataBlockRange` cases in `test/helpers.test.ts`: both bounds flagged even when 0; `sigFailed` preserved; zero deadline → open-ended range.
- `yarn hardhat compile` + full `test/helpers.test.ts` suite passes (5/5).

Made with [Cursor](https://cursor.com)